### PR TITLE
Resolve several gcc testsuite issue.

### DIFF
--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -702,7 +702,7 @@ enum reg_class
 /* Accept arguments in a0-a7 and/or fa0-fa7. */
 #define FUNCTION_ARG_REGNO_P(N)					\
   (IN_RANGE((N), GP_ARG_FIRST, GP_ARG_LAST)			\
-   || IN_RANGE((N), FP_ARG_FIRST, FP_ARG_LAST))
+   || (!TARGET_SOFT_FLOAT && IN_RANGE((N), FP_ARG_FIRST, FP_ARG_LAST)))
 
 /* The ABI views the arguments as a structure, of which the first 8
    words go in registers and the rest go on the stack.  If I < 8, N, the Ith

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -681,8 +681,7 @@
 	(mult:DI (any_extend:DI
 		   (match_operand:SI 1 "register_operand" "r"))
 		 (any_extend:DI
-		   (match_operand:SI 2 "register_operand" "r"))))
-  (clobber (match_scratch:SI 3 "=r"))]
+		   (match_operand:SI 2 "register_operand" "r"))))]
   "TARGET_MULDIV && !TARGET_64BIT"
 {
   rtx temp = gen_reg_rtx (SImode);
@@ -714,8 +713,7 @@
 	(mult:DI (zero_extend:DI
 		   (match_operand:SI 1 "register_operand" "r"))
 		 (sign_extend:DI
-		   (match_operand:SI 2 "register_operand" "r"))))
-  (clobber (match_scratch:SI 3 "=r"))]
+		   (match_operand:SI 2 "register_operand" "r"))))]
   "TARGET_MULDIV && !TARGET_64BIT"
 {
   rtx temp = gen_reg_rtx (SImode);

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -20,23 +20,23 @@
 
 m32
 Target RejectNegative Mask(32BIT)
-Generate RV32 code
+Generate RV32 code.
 
 m64
 Target RejectNegative InverseMask(32BIT, 64BIT)
-Generate RV64 code
+Generate RV64 code.
 
 mbranch-cost=
 Target RejectNegative Joined UInteger Var(riscv_branch_cost)
--mbranch-cost=COST	Set the cost of branches to roughly COST instructions
+-mbranch-cost=COST	Set the cost of branches to roughly COST instructions.
 
 mhard-float
 Target Report RejectNegative InverseMask(SOFT_FLOAT_ABI, HARD_FLOAT_ABI)
-Allow the use of hardware floating-point ABI and instructions
+Allow the use of hardware floating-point ABI and instructions.
 
 mmemcpy
 Target Report Mask(MEMCPY)
-Don't optimize block moves
+Don't optimize block moves.
 
 mplt
 Target Report Var(TARGET_PLT) Init(1)
@@ -44,27 +44,27 @@ When generating -fpic code, allow the use of PLTs. Ignored for fno-pic.
 
 msoft-float
 Target Report RejectNegative Mask(SOFT_FLOAT_ABI)
-Prevent the use of all hardware floating-point instructions
+Prevent the use of all hardware floating-point instructions.
 
 mno-fdiv
 Target Report RejectNegative Mask(NO_FDIV)
-Don't use hardware floating-point divide and square root instructions
+Don't use hardware floating-point divide and square root instructions.
 
 mfdiv
 Target Report RejectNegative InverseMask(NO_FDIV, FDIV)
-Use hardware floating-point divide and square root instructions
+Use hardware floating-point divide and square root instructions.
 
 march=
 Target RejectNegative Joined Var(riscv_arch_string)
--march=			Generate code for given RISC-V ISA (e.g. RV64IM)
+-march=			Generate code for given RISC-V ISA (e.g. RV64IM).
 
 mtune=
 Target RejectNegative Joined Var(riscv_tune_string)
--mtune=PROCESSOR	Optimize the output for PROCESSOR
+-mtune=PROCESSOR	Optimize the output for PROCESSOR.
 
 msmall-data-limit=
 Target Joined Separate UInteger Var(g_switch_value) Init(8)
--msmall-data-limit=<number>	Put global and static data smaller than <number> bytes into a special section (on some targets)
+-msmall-data-limit=<number>	Put global and static data smaller than <number> bytes into a special section (on some targets).
 
 matomic
 Target Report Mask(ATOMIC)
@@ -76,16 +76,16 @@ Use hardware instructions for integer multiplication and division.
 
 mrvc
 Target Report Mask(RVC)
-Use compressed instruction encoding
+Use compressed instruction encoding.
 
 msave-restore
 Target Report Mask(SAVE_RESTORE)
-Use smaller but slower prologue and epilogue code
+Use smaller but slower prologue and epilogue code.
 
 mcmodel=
 Target RejectNegative Joined Var(riscv_cmodel_string)
-Use given RISC-V code model (medlow or medany)
+Use given RISC-V code model (medlow or medany).
 
 mexplicit-relocs
 Target Report Mask(EXPLICIT_RELOCS)
-Use %reloc() operators, rather than assembly macros, to load addresses
+Use %reloc() operators, rather than assembly macros, to load addresses.

--- a/gcc/testsuite/lib/target-supports.exp
+++ b/gcc/testsuite/lib/target-supports.exp
@@ -6868,6 +6868,7 @@ proc check_effective_target_logical_op_short_circuit {} {
 	 || [istarget s390*-*-*]
 	 || [istarget powerpc*-*-*]
 	 || [istarget nios2*-*-*]
+	 || [istarget riscv*-*-*]
 	 || [istarget visium-*-*]
 	 || [check_effective_target_arm_cortex_m] } {
 	return 1

--- a/libgcc/config/riscv/t-elf64
+++ b/libgcc/config/riscv/t-elf64
@@ -1,2 +1,1 @@
-LIB2FUNCS_EXCLUDE += _divdi3 _moddi3 _udivdi3 _umoddi3 _muldi3 _multi3 \
-		     _divsi3 _modsi3 _udivsi3 _umodsi3 \
+LIB2FUNCS_EXCLUDE += _divsi3 _modsi3 _udivsi3 _umodsi3 _mulsi3 _muldi3


### PR DESCRIPTION
This patch set resolve about ~50% of gcc testsuite fail.

configure: riscv64-unknown-elf + soft-float

gcc testsuite result before those patch:

                === gcc Summary ===

 # of expected passes            79639
 # of unexpected failures        450
 # of unexpected successes       1
 # of expected failures          101
 # of unresolved testcases       143
 # of unsupported tests          1653

                === g++ Summary ===

 # of expected passes            82555
 # of unexpected failures        1242
 # of expected failures          260
 # of unresolved testcases       5
 # of unsupported tests          3960


gcc testsuite result after those patch with gdb sim fix[1]:
                === gcc Summary ===

 # of expected passes            79827
 # of unexpected failures        214 (-236)
 # of unexpected successes       1
 # of expected failures          102
 # of unresolved testcases       71
 # of unsupported tests          1664

                === g++ Summary ===
 # of expected passes            82578
 # of unexpected failures        1222 (-20)
 # of expected failures          260
 # of unresolved testcases       2
 # of unsupported tests          3960


[1] https://github.com/riscv/riscv-binutils-gdb/pull/15