### PR TITLE
Fix multi-lib for RV32I

### DIFF
--- a/gcc/config/riscv/t-linux64
+++ b/gcc/config/riscv/t-linux64
@@ -1,5 +1,11 @@
 # Build the libraries for both hard and soft floating point
 
-MULTILIB_OPTIONS = m64/m32 msoft-float mno-atomic
-MULTILIB_DIRNAMES = 64 32 soft-float no-atomic
-MULTILIB_OSDIRNAMES = ../lib ../lib32 soft-float no-atomic
+MULTILIB_OPTIONS = m64/m32 mno-atomic
+MULTILIB_DIRNAMES = 64 32 no-atomic
+MULTILIB_OSDIRNAMES = ../lib ../lib32 no-atomic
+
+ifneq ($(with_float), soft)
+MULTILIB_OPTIONS += msoft-float
+MULTILIB_DIRNAMES += soft-float
+MULTILIB_OSDIRNAMES += soft-float
+endif


### PR DESCRIPTION
Don't use multi-lib option to soft-float when it's default since it's will make gcc can't find library in default path (eg: lib or lib32).