### PR TITLE
add options to individually include hw mul and div/mod

### DIFF
--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -45,9 +45,9 @@ riscv_parse_arch_string (const char *isa, int *flags)
       return;
     }
 
-  *flags &= ~MASK_MULDIV;
+  *flags &= ~(MASK_MUL | MASK_DIV);
   if (*p == 'M')
-    *flags |= MASK_MULDIV, p++;
+    *flags |= (MASK_MUL | MASK_DIV), p++;
 
   *flags &= ~MASK_ATOMIC;
   if (*p == 'A')
@@ -110,7 +110,16 @@ riscv_handle_option (struct gcc_options *opts,
     case OPT_march_:
       riscv_parse_arch_string (decoded->arg, &opts->x_target_flags);
       return true;
-
+    case OPT_mmuldiv:
+      if (decoded->value)
+         {
+            opts->x_target_flags |= (MASK_MUL | MASK_DIV);
+         }
+      else
+         {
+            opts->x_target_flags &= ~(MASK_MUL | MASK_DIV);
+         }
+      return true;
     default:
       return true;
     }

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -63,7 +63,11 @@ along with GCC; see the file COPYING3.  If not see
       if (TARGET_ATOMIC)						\
 	builtin_define ("__riscv_atomic");				\
 									\
-      if (TARGET_MULDIV)						\
+      if (TARGET_MUL)							\
+	builtin_define ("__riscv_mul");					\
+      if (TARGET_DIV)							\
+	builtin_define ("__riscv_div");					\
+      if (TARGET_DIV && TARGET_MUL)					\
 	builtin_define ("__riscv_muldiv");				\
 									\
       if (TARGET_HARD_FLOAT_ABI)					\

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -566,13 +566,13 @@
   [(set (match_operand:GPR 0 "register_operand")
 	(mult:GPR (match_operand:GPR 1 "reg_or_0_operand")
 		   (match_operand:GPR 2 "register_operand")))]
-  "TARGET_MULDIV")
+  "TARGET_MUL")
 
 (define_insn "*mulsi3"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(mult:SI (match_operand:GPR 1 "register_operand" "r")
 		  (match_operand:GPR2 2 "register_operand" "r")))]
-  "TARGET_MULDIV"
+  "TARGET_MUL"
   { return TARGET_64BIT ? "mulw\t%0,%1,%2" : "mul\t%0,%1,%2"; }
   [(set_attr "type" "imul")
    (set_attr "mode" "SI")])
@@ -581,7 +581,7 @@
   [(set (match_operand:SI 0 "register_operand" "=r")
 	     (mult:SI (truncate:SI (match_operand:DI 1 "register_operand" "r"))
 		      (truncate:SI (match_operand:DI 2 "register_operand" "r"))))]
-  "TARGET_MULDIV && TARGET_64BIT"
+  "TARGET_MUL && TARGET_64BIT"
   "mulw\t%0,%1,%2"
   [(set_attr "type" "imul")
    (set_attr "mode" "SI")])
@@ -591,7 +591,7 @@
           (truncate:SI
 	     (mult:DI (match_operand:DI 1 "register_operand" "r")
 		      (match_operand:DI 2 "register_operand" "r"))))]
-  "TARGET_MULDIV && TARGET_64BIT"
+  "TARGET_MUL && TARGET_64BIT"
   "mulw\t%0,%1,%2"
   [(set_attr "type" "imul")
    (set_attr "mode" "SI")])
@@ -600,7 +600,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(mult:DI (match_operand:DI 1 "register_operand" "r")
 		  (match_operand:DI 2 "register_operand" "r")))]
-  "TARGET_MULDIV && TARGET_64BIT"
+  "TARGET_MUL && TARGET_64BIT"
   "mul\t%0,%1,%2"
   [(set_attr "type" "imul")
    (set_attr "mode" "DI")])
@@ -618,7 +618,7 @@
   [(set (match_operand:TI 0 "register_operand")
         (mult:TI (any_extend:TI (match_operand:DI 1 "register_operand"))
                  (any_extend:TI (match_operand:DI 2 "register_operand"))))]
-  "TARGET_MULDIV && TARGET_64BIT"
+  "TARGET_MUL && TARGET_64BIT"
 {
   rtx low = gen_reg_rtx (DImode);
   emit_insn (gen_muldi3 (low, operands[1], operands[2]));
@@ -640,7 +640,7 @@
 		     (any_extend:TI
 		       (match_operand:DI 2 "register_operand" "r")))
 	    (const_int 64))))]
-  "TARGET_MULDIV && TARGET_64BIT"
+  "TARGET_MUL && TARGET_64BIT"
   "mulh<u>\t%0,%1,%2"
   [(set_attr "type" "imul")
    (set_attr "mode" "DI")])
@@ -649,7 +649,7 @@
   [(set (match_operand:TI 0 "register_operand")
         (mult:TI (zero_extend:TI (match_operand:DI 1 "register_operand"))
                  (sign_extend:TI (match_operand:DI 2 "register_operand"))))]
-  "TARGET_MULDIV && TARGET_64BIT"
+  "TARGET_MUL && TARGET_64BIT"
 {
   rtx low = gen_reg_rtx (DImode);
   emit_insn (gen_muldi3 (low, operands[1], operands[2]));
@@ -671,7 +671,7 @@
 		     (sign_extend:TI
 		       (match_operand:DI 2 "register_operand" "r")))
 	    (const_int 64))))]
-  "TARGET_MULDIV && TARGET_64BIT"
+  "TARGET_MUL && TARGET_64BIT"
   "mulhsu\t%0,%2,%1"
   [(set_attr "type" "imul")
    (set_attr "mode" "DI")])
@@ -682,7 +682,7 @@
 		   (match_operand:SI 1 "register_operand" "r"))
 		 (any_extend:DI
 		   (match_operand:SI 2 "register_operand" "r"))))]
-  "TARGET_MULDIV && !TARGET_64BIT"
+  "TARGET_MUL && !TARGET_64BIT"
 {
   rtx temp = gen_reg_rtx (SImode);
   emit_insn (gen_mulsi3 (temp, operands[1], operands[2]));
@@ -702,7 +702,7 @@
 		     (any_extend:DI
 		       (match_operand:SI 2 "register_operand" "r")))
 	    (const_int 32))))]
-  "TARGET_MULDIV && !TARGET_64BIT"
+  "TARGET_MUL && !TARGET_64BIT"
   "mulh<u>\t%0,%1,%2"
   [(set_attr "type" "imul")
    (set_attr "mode" "SI")])
@@ -714,7 +714,7 @@
 		   (match_operand:SI 1 "register_operand" "r"))
 		 (sign_extend:DI
 		   (match_operand:SI 2 "register_operand" "r"))))]
-  "TARGET_MULDIV && !TARGET_64BIT"
+  "TARGET_MUL && !TARGET_64BIT"
 {
   rtx temp = gen_reg_rtx (SImode);
   emit_insn (gen_mulsi3 (temp, operands[1], operands[2]));
@@ -734,7 +734,7 @@
 		     (sign_extend:DI
 		       (match_operand:SI 2 "register_operand" "r")))
 	    (const_int 32))))]
-  "TARGET_MULDIV && !TARGET_64BIT"
+  "TARGET_MUL && !TARGET_64BIT"
   "mulhsu\t%0,%2,%1"
   [(set_attr "type" "imul")
    (set_attr "mode" "SI")])
@@ -751,7 +751,7 @@
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(any_div:SI (match_operand:SI 1 "register_operand" "r")
 		  (match_operand:SI 2 "register_operand" "r")))]
-  "TARGET_MULDIV"
+  "TARGET_DIV"
   { return TARGET_64BIT ? "div<u>w\t%0,%1,%2" : "div<u>\t%0,%1,%2"; }
   [(set_attr "type" "idiv")
    (set_attr "mode" "SI")])
@@ -760,7 +760,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(any_div:DI (match_operand:DI 1 "register_operand" "r")
 		  (match_operand:DI 2 "register_operand" "r")))]
-  "TARGET_MULDIV && TARGET_64BIT"
+  "TARGET_DIV && TARGET_64BIT"
   "div<u>\t%0,%1,%2"
   [(set_attr "type" "idiv")
    (set_attr "mode" "DI")])
@@ -769,7 +769,7 @@
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(any_mod:SI (match_operand:SI 1 "register_operand" "r")
 		  (match_operand:SI 2 "register_operand" "r")))]
-  "TARGET_MULDIV"
+  "TARGET_DIV"
   { return TARGET_64BIT ? "rem<u>w\t%0,%1,%2" : "rem<u>\t%0,%1,%2"; }
   [(set_attr "type" "idiv")
    (set_attr "mode" "SI")])
@@ -778,7 +778,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(any_mod:DI (match_operand:DI 1 "register_operand" "r")
 		  (match_operand:DI 2 "register_operand" "r")))]
-  "TARGET_MULDIV && TARGET_64BIT"
+  "TARGET_DIV && TARGET_64BIT"
   "rem<u>\t%0,%1,%2"
   [(set_attr "type" "idiv")
    (set_attr "mode" "DI")])

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -47,7 +47,7 @@ Target Report RejectNegative Mask(SOFT_FLOAT_ABI)
 Prevent the use of all hardware floating-point instructions.
 
 mno-fdiv
-Target Report RejectNegative Mask(NO_FDIV)
+Target Report RejectNegative Undocumented Mask(NO_FDIV)
 Don't use hardware floating-point divide and square root instructions.
 
 mfdiv

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -71,8 +71,16 @@ Target Report Mask(ATOMIC)
 Use hardware atomic memory instructions.
 
 mmuldiv
-Target Report Mask(MULDIV)
+Target Report Var(TARGET_muldiv)
 Use hardware instructions for integer multiplication and division.
+
+mmul
+Target Report Mask(MUL)
+Use hardware instructions for integer multiplication
+
+mdiv
+Target Report Mask(DIV)
+Use hardware instructions for integer division.
 
 mrvc
 Target Report Mask(RVC)


### PR DESCRIPTION
I added -mmul and -mdiv to the target specific options. I kept -mmuldiv around for legacy. 

If anyone knows a better way of making -mmuldiv simply expand to -mmul -mdiv, I'd like to know, otherwise i think my way works.