### PR TITLE
Review testsuite and clean up

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -455,7 +455,6 @@ powerpc*-*-*)
 	;;
 riscv*)
 	cpu_type=riscv
-	need_64bit_hwint=yes
 	;;
 rs6000*-*-*)
 	extra_options="${extra_options} g.opt fused-madd.opt rs6000/rs6000-tables.opt"

--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -388,7 +388,7 @@ riscv_parse_cpu (const char *cpu_string)
     if (strcmp (riscv_cpu_info_table[i].name, cpu_string) == 0)
       return riscv_cpu_info_table + i;
 
-  error ("unknown cpu `%s'", cpu_string);
+  error ("unknown cpu `%s' for -mtune", cpu_string);
   return riscv_cpu_info_table;
 }
 

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -380,8 +380,6 @@ along with GCC; see the file COPYING3.  If not see
 
    - 32 integer registers
    - 32 floating point registers
-   - 32 vector integer registers
-   - 32 vector floating point registers
    - 2 fake registers:
 	- ARG_POINTER_REGNUM
 	- FRAME_POINTER_REGNUM */

--- a/gcc/testsuite/g++.dg/cpp0x/constexpr-rom.C
+++ b/gcc/testsuite/g++.dg/cpp0x/constexpr-rom.C
@@ -2,7 +2,7 @@
 // { dg-do compile { target c++11 } }
 // { dg-additional-options -G0 { target { { alpha*-*-* frv*-*-* ia64-*-* lm32*-*-* m32r*-*-* microblaze*-*-* mips*-*-* nios2-*-* powerpc*-*-* rs6000*-*-* } && { ! { *-*-darwin* *-*-aix* alpha*-*-*vms* } } } } }
 // { dg-final { scan-assembler "\\.rdata" { target mips*-*-* } } }
-// { dg-final { scan-assembler "rodata" { target { { *-*-linux-gnu *-*-gnu* *-*-elf } && { ! mips*-*-* } } } } }
+// { dg-final { scan-assembler "rodata" { target { { *-*-linux-gnu *-*-gnu* *-*-elf } && { ! { mips*-*-* riscv*-*-* } } } } } }
 
 struct Data
 {

--- a/gcc/testsuite/gcc.dg/ifcvt-4.c
+++ b/gcc/testsuite/gcc.dg/ifcvt-4.c
@@ -1,6 +1,6 @@
 /* { dg-options "-fdump-rtl-ce1 -O2 --param max-rtl-if-conversion-insns=3" } */
 /* { dg-additional-options "-misel" { target { powerpc*-*-* } } } */
-/* { dg-skip-if "Multiple set if-conversion not guaranteed on all subtargets" { "arm*-*-* hppa*64*-*-* visium-*-*" } }  */
+/* { dg-skip-if "Multiple set if-conversion not guaranteed on all subtargets" { "arm*-*-* hppa*64*-*-* visium-*-*" riscv*-*-* } }  */
 
 typedef int word __attribute__((mode(word)));
 

--- a/gcc/testsuite/gcc.dg/loop-8.c
+++ b/gcc/testsuite/gcc.dg/loop-8.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O1 -fdump-rtl-loop2_invariant" } */
-/* { dg-skip-if "unexpected IV" { "hppa*-*-* visium-*-*" } { "*" } { "" } } */
+/* { dg-skip-if "unexpected IV" { "hppa*-*-* visium-*-* riscv*-*-*" } { "*" } { "" } } */
 
 void
 f (int *a, int *b)

--- a/gcc/testsuite/gcc.dg/tree-ssa/20040204-1.c
+++ b/gcc/testsuite/gcc.dg/tree-ssa/20040204-1.c
@@ -33,4 +33,4 @@ void test55 (int x, int y)
    that the && should be emitted (based on BRANCH_COST).  Fix this
    by teaching dom to look through && and register all components
    as true.  */
-/* { dg-final { scan-tree-dump-times "link_error" 0 "optimized" { xfail { ! "alpha*-*-* arm*-*-* aarch64*-*-* powerpc*-*-* cris-*-* crisv32-*-* hppa*-*-* i?86-*-* mmix-*-* mips*-*-* m68k*-*-* moxie-*-* nds32*-*-* s390*-*-* sh*-*-* sparc*-*-* spu-*-* visium-*-* x86_64-*-*" } } } } */
+/* { dg-final { scan-tree-dump-times "link_error" 0 "optimized" { xfail { ! "alpha*-*-* arm*-*-* aarch64*-*-* powerpc*-*-* cris-*-* crisv32-*-* hppa*-*-* i?86-*-* mmix-*-* mips*-*-* m68k*-*-* moxie-*-* nds32*-*-* s390*-*-* sh*-*-* sparc*-*-* spu-*-* visium-*-* x86_64-*-* riscv*-*-*" } } } } */

--- a/gcc/testsuite/gcc.dg/tree-ssa/ssa-dom-cse-2.c
+++ b/gcc/testsuite/gcc.dg/tree-ssa/ssa-dom-cse-2.c
@@ -25,4 +25,4 @@ foo ()
    but the loop reads only one element at a time, and DOM cannot resolve these.
    The same happens on powerpc depending on the SIMD support available.  */
 
-/* { dg-final { scan-tree-dump "return 28;" "optimized" { xfail { { alpha*-*-* hppa*64*-*-* powerpc64*-*-* } || { sparc*-*-* && lp64 } } } } } */
+/* { dg-final { scan-tree-dump "return 28;" "optimized" { xfail { { alpha*-*-* hppa*64*-*-* powerpc64*-*-* riscv*64*-*-* } || { sparc*-*-* && lp64 } } } } } */

--- a/gcc/testsuite/gcc.dg/tree-ssa/ssa-fre-3.c
+++ b/gcc/testsuite/gcc.dg/tree-ssa/ssa-fre-3.c
@@ -5,7 +5,7 @@
 
    When the condition is true, we distribute "(int) (a + b)" as
    "(int) a + (int) b", otherwise we keep the original.  */
-/* { dg-do compile { target { { ! mips64 } && { ! spu-*-* } } } } */
+/* { dg-do compile { target { { ! mips64 } && { { ! spu-*-* } && { ! riscv*64*-*-* } } } } } */
 /* { dg-options "-O -fno-tree-forwprop -fno-tree-ccp -fwrapv -fdump-tree-fre1-details" } */
 
 /* From PR14844.  */


### PR DESCRIPTION
In this change set, I've review some fail case and mark skip if it's reasonable for RISC-V.

Testsuite after this patch set:
```
									rv32i			rv32g			rv64i			rv64g
gcc       # of expected failures   	  127 (    0)	  127 (    0)	  128 (    0)	  128 (    0)	
          # of expected passes     	82378 (   -2)	82382 (   -2)	83797 (    0)	83817 (    0)	
          # of unexpected failures 	   62 (   -5)	   77 (   -5)	   77 (   -7)	   92 (   -7)	
          # of unexpected successes	    0 (   -1)	    0 (   -1)	    0 (   -1)	    0 (   -1)	
          # of unresolved testcases	   10 (    0)	   10 (    0)	   10 (    0)	   10 (    0)	
          # of unsupported tests   	 1645 (    2)	 1636 (    2)	 1515 (    2)	 1498 (    2)	
g++       # of expected failures   	  303 (    0)	  303 (    0)	  303 (    0)	  303 (    0)	
          # of expected passes     	90602 (    0)	90597 (    0)	92481 (    5)	92482 (    6)	
          # of unexpected failures 	   30 (   -2)	   35 (   -2)	   23 (   -4)	   22 (   -5)	
          # of unexpected successes	    2 (    0)	    2 (    0)	    2 (    0)	    2 (    0)	
          # of unresolved testcases	    0 (    0)	    0 (    0)	    0 (    0)	    0 (    0)	
          # of unsupported tests   	 3876 (    0)	 3876 (    0)	 3853 (    0)	 3853 (    0)	

```