### PR TITLE
Change back TARGET_HAVE_TLS to HAVE_AS_TLS since elf toolchain no tls support

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -4096,8 +4096,10 @@ riscv_cannot_copy_insn_p (rtx_insn *insn)
 #undef TARGET_SCALAR_MODE_SUPPORTED_P
 #define TARGET_SCALAR_MODE_SUPPORTED_P riscv_scalar_mode_supported_p
 
+#ifdef HAVE_AS_TLS
 #undef TARGET_HAVE_TLS
 #define TARGET_HAVE_TLS true
+#endif
 
 #undef TARGET_CANNOT_FORCE_CONST_MEM
 #define TARGET_CANNOT_FORCE_CONST_MEM riscv_cannot_force_const_mem


### PR DESCRIPTION
We need TARGET_HAVE_TLS depend on HAVE_AS_TLS for elf toolchain, otherwise linker will complain __tls_get_addr not found.