### PR TITLE
Use FENCE to implement C++ release

### DIFF
--- a/gcc/config/riscv/sync.md
+++ b/gcc/config/riscv/sync.md
@@ -82,7 +82,8 @@
        (match_operand:SI 2 "const_int_operand")]      ;; model
       UNSPEC_ATOMIC_STORE))]
   "TARGET_ATOMIC"
-  "amoswap.<amo>%A2 zero,%z1,%0")
+  "%F2amoswap.<amo>%A2 zero,%z1,%0"
+  [(set (attr "length") (const_int 8))])
 
 (define_insn "atomic_<atomic_optab><mode>"
   [(set (match_operand:GPR 0 "memory_operand" "+A")
@@ -92,7 +93,8 @@
 	   (match_operand:SI 2 "const_int_operand")] ;; model
 	 UNSPEC_SYNC_OLD_OP))]
   "TARGET_ATOMIC"
-  "amo<insn>.<amo>%A2 zero,%z1,%0")
+  "%F2amo<insn>.<amo>%A2 zero,%z1,%0"
+  [(set (attr "length") (const_int 8))])
 
 (define_insn "atomic_fetch_<atomic_optab><mode>"
   [(set (match_operand:GPR 0 "register_operand" "=&r")
@@ -104,7 +106,8 @@
 	   (match_operand:SI 3 "const_int_operand")] ;; model
 	 UNSPEC_SYNC_OLD_OP))]
   "TARGET_ATOMIC"
-  "amo<insn>.<amo>%A3 %0,%z2,%1")
+  "%F3amo<insn>.<amo>%A3 %0,%z2,%1"
+  [(set (attr "length") (const_int 8))])
 
 (define_insn "atomic_exchange<mode>"
   [(set (match_operand:GPR 0 "register_operand" "=&r")
@@ -115,7 +118,8 @@
    (set (match_dup 1)
 	(match_operand:GPR 2 "register_operand" "0"))]
   "TARGET_ATOMIC"
-  "amoswap.<amo>%A3 %0,%z2,%1")
+  "%F3amoswap.<amo>%A3 %0,%z2,%1"
+  [(set (attr "length") (const_int 8))])
 
 (define_insn "atomic_cas_value_strong<mode>"
   [(set (match_operand:GPR 0 "register_operand" "=&r")
@@ -128,8 +132,8 @@
 	 UNSPEC_COMPARE_AND_SWAP))
    (clobber (match_scratch:GPR 6 "=&r"))]
   "TARGET_ATOMIC"
-  "1: lr.<amo>%A5 %0,%1; bne %0,%z2,1f; sc.<amo>%A4 %6,%z3,%1; bnez %6,1b; 1:"
-  [(set (attr "length") (const_int 16))])
+  "%F5 1: lr.<amo>%A5 %0,%1; bne %0,%z2,1f; sc.<amo>%A4 %6,%z3,%1; bnez %6,1b; 1:"
+  [(set (attr "length") (const_int 20))])
 
 (define_expand "atomic_compare_and_swap<mode>"
   [(match_operand:SI 0 "register_operand" "")   ;; bool output


### PR DESCRIPTION
The RISC-V memory model isn't completely sorted out, but this conservative
option will work regardless.  It can always be relaxed later if need be.

Acquire is still implemented with .aq.