### PR TITLE
Don't build the F multilibs on Linux

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -4019,10 +4019,8 @@ case "${target}" in
 		"")
 			case "${with_arch}" in
 			rv32*d* | rv32g*) with_abi=ilp32d ;;
-			rv32*f*) with_abi=ilp32f ;;
 			rv32*) with_abi=ilp32 ;;
 			rv64*d* | rv64g*) with_abi=lp64d ;;
-			rv64*f* ) with_abi=lp64f ;;
 			rv64*) with_abi=lp64 ;;
 			esac
 			;;

--- a/gcc/config/riscv/t-linux
+++ b/gcc/config/riscv/t-linux
@@ -23,10 +23,8 @@ MULTILIB_OSDIRNAMES =    ../lib32    ../lib64        ../lib32        ../lib64   
 # supported (rv64imafd/ilp32).
 MULTILIB_REQUIRED  =
 MULTILIB_REQUIRED += march=rv32ima/mabi=ilp32
-MULTILIB_REQUIRED += march=rv32imaf/mabi=ilp32f
 MULTILIB_REQUIRED += march=rv32imafd/mabi=ilp32d
 MULTILIB_REQUIRED += march=rv64ima/mabi=lp64
-MULTILIB_REQUIRED += march=rv64imaf/mabi=lp64f
 MULTILIB_REQUIRED += march=rv64imafd/mabi=lp64d
 
 # There's a hack in the multilibs we build: it appears that if I tell GCC to


### PR DESCRIPTION
We've decided that we're not going to add F to the default multilib set on Linux, since it's unlikely that general purpose hardware will have single-precision but won't have double precision.  We'll still support the non-multilib {lp64,ilp32}f ABIs on all -march targets, and distributions are free to build them if they think they're interesting for their use cases, they just won't be in the default Linux make fragment.

@kito-cheng This also reverts your recent commit that I merged -- since we won't have an F multilib then users shouldn't get it by default.