### PR TITLE
Fix riscv_flatten_aggregate_field for handle array of empty struct

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -2217,7 +2217,7 @@ riscv_flatten_aggregate_field (const_tree type,
 							 subfields, 0, offset);
 
 	/* Can't handle incomplete types nor sizes that are not fixed.  */
-	if (n_subfields < 0
+	if (n_subfields <= 0
 	    || !COMPLETE_TYPE_P (type)
 	    || TREE_CODE (TYPE_SIZE (type)) != INTEGER_CST
 	    || !index


### PR DESCRIPTION
 - Test case:
```
struct S12 { struct{}a[0]; } ;
extern struct S12 s12;
struct S12 a12[5];
struct S12 check12 (struct S12 arg0, struct S12 *arg1, struct S12 arg2)
{
  struct S12 ret;
  return ret;
}
```