### PR TITLE
Split the RISC-V target makefrags into multilib and nomultilib

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -2035,7 +2035,11 @@ microblaze*-*-elf)
         ;;
 riscv*-*-linux*)
 	tm_file="elfos.h gnu-user.h linux.h glibc-stdint.h ${tm_file} riscv/linux.h"
-	tmake_file="${tmake_file} riscv/t-linux"
+	case "x${enable_multilib}" in
+	xno) tmake_file="${tmake_file} riscv/t-linux-nomultilib" ;;
+	xyes) tmake_file="${tmake_file} riscv/t-linux-multilib" ;;
+	*) echo "Unknown value for enable_multilib"; exit 1
+	esac
 	gnu_ld=yes
 	gas=yes
 	# Force .init_array support.  The configure script cannot always
@@ -2044,7 +2048,11 @@ riscv*-*-linux*)
 	;;
 riscv*-*-elf*)
 	tm_file="elfos.h newlib-stdint.h ${tm_file} riscv/elf.h"
-	tmake_file="${tmake_file} riscv/t-elf"
+	case "x${enable_multilib}" in
+	xno) tmake_file="${tmake_file} riscv/t-elf-nomultilib" ;;
+	xyes) tmake_file="${tmake_file} riscv/t-elf-multilib" ;;
+	*) echo "Unknown value for enable_multilib"; exit 1
+	esac
 	gnu_ld=yes
 	gas=yes
 	# Force .init_array support.  The configure script cannot always

--- a/gcc/config/riscv/t-elf-multilib
+++ b/gcc/config/riscv/t-elf-multilib
@@ -1,0 +1,2 @@
+# For the time being, Linux and Newlib have the same multilib settings.
+include $(srcdir)/config/riscv/t-linux-multilib

--- a/gcc/config/riscv/t-elf-nomultilib
+++ b/gcc/config/riscv/t-elf-nomultilib
@@ -1,2 +1,2 @@
 # For the time being, Linux and Newlib have the same multilib settings.
-include $(srcdir)/config/riscv/t-linux
+include $(srcdir)/config/riscv/t-linux-nomultilib

--- a/gcc/config/riscv/t-linux-multilib
+++ b/gcc/config/riscv/t-linux-multilib
@@ -1,0 +1,13 @@
+# This is a bit odd: the "nomultilib" configurtion defines all the multilibs,
+# and this multilib configuration just whitelists the ones we want to build.
+include $(srcdir)/config/riscv/t-linux-nomultilib
+
+# We don't actually support all the possible multilib configurations on RISC-V.
+# Here's a blessed list of the interesting ones.  Some will never be supported
+# (rv32imafd/lp64), some are impossible (rv64ima/lp64d) and some will eventually be
+# supported (rv64imafd/ilp32).
+MULTILIB_REQUIRED  =
+MULTILIB_REQUIRED += march=rv32ima/mabi=ilp32
+MULTILIB_REQUIRED += march=rv32imafd/mabi=ilp32d
+MULTILIB_REQUIRED += march=rv64ima/mabi=lp64
+MULTILIB_REQUIRED += march=rv64imafd/mabi=lp64d

--- a/gcc/config/riscv/t-linux-nomultilib
+++ b/gcc/config/riscv/t-linux-nomultilib
@@ -13,19 +13,9 @@
 #  CFLAGS:    -march=rv32imafd -mabi=ilp32d
 #  DIRNAME:   GCC_HOME/rv32imafd/ilp32d
 #  OSDIRNAME: /lib32/ilp32d
-MULTILIB_OPTIONS    = march=rv32g/march=rv64g/march=rv32imafd/march=rv64imafd/march=rv32imaf/march=rv64imaf/march=rv32ima/march=rv64ima mabi=ilp32/mabi=ilp32f/mabi=ilp32d/mabi=lp64/mabi=lp64f/mabi=lp64d
-MULTILIB_DIRNAMES   =       lib32       lib64           lib32           lib64          lib32          lib64         lib32         lib64      ilp32      ilp32f      ilp32d      lp64      lp64f      lp64d
-MULTILIB_OSDIRNAMES =    ../lib32    ../lib64        ../lib32        ../lib64       ../lib32       ../lib64      ../lib32      ../lib64      ilp32      ilp32f      ilp32d      lp64      lp64f      lp64d
-
-# We don't actually support all the possible multilib configurations on RISC-V.
-# Here's a blessed list of the interesting ones.  Some will never be supported
-# (rv32imafd/lp64), some are impossible (rv64ima/lp64d) and some will eventually be
-# supported (rv64imafd/ilp32).
-MULTILIB_REQUIRED  =
-MULTILIB_REQUIRED += march=rv32ima/mabi=ilp32
-MULTILIB_REQUIRED += march=rv32imafd/mabi=ilp32d
-MULTILIB_REQUIRED += march=rv64ima/mabi=lp64
-MULTILIB_REQUIRED += march=rv64imafd/mabi=lp64d
+MULTILIB_OPTIONS    = march=rv32g/march=rv64g/march=rv32imafd/march=rv64imafd/march=rv32ima/march=rv64ima/march=rv32imaf/march=rv64imaf mabi=ilp32/mabi=ilp32f/mabi=ilp32d/mabi=lp64/mabi=lp64f/mabi=lp64d
+MULTILIB_DIRNAMES   =       lib32       lib64           lib32           lib64         lib32         lib64          lib32          lib64      ilp32      ilp32f      ilp32d      lp64      lp64f      lp64d
+MULTILIB_OSDIRNAMES =    ../lib32    ../lib64        ../lib32        ../lib64      ../lib32      ../lib64       ../lib32    ../lib64      ilp32      ilp32f      ilp32d      lp64      lp64f      lp64d
 
 # There's a hack in the multilibs we build: it appears that if I tell GCC to
 # build a multilib for rv64g then it just builds one of them and ignores the


### PR DESCRIPTION
This is the best way I can figure out how to make this work: we now have
two target makefile fragments for each RISC-V OS, one that for multilib
support and one for non-multilib.  The only difference is that the
multilib one sets MULTILIB_REQUIRED, as setting that seems to screw up
the non-multilib paths.

The other option would be to modify something like LINK_SPEC, but I
think this is better because it allows us to later add to the multilibs
that we're building and transparently support those new ones.