### PR TITLE
Add fnma<mode>4 and fnms<mode>4 pattern

### DIFF
--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -822,6 +822,28 @@
   [(set_attr "type" "fmadd")
    (set_attr "mode" "<UNITMODE>")])
 
+(define_insn "fnma<mode>4"
+  [(set (match_operand:ANYF 0 "register_operand" "=f")
+    (fma:ANYF
+      (neg:ANYF	(match_operand:ANYF 1 "register_operand" "f"))
+      (match_operand:ANYF 2 "register_operand" "f")
+      (match_operand:ANYF 3 "register_operand" "f")))]
+  "TARGET_HARD_FLOAT"
+  "fnmadd.<fmt>\t%0,%1,%2,%3"
+  [(set_attr "type" "fmadd")
+   (set_attr "mode" "<UNITMODE>")])
+
+(define_insn "fnms<mode>4"
+  [(set (match_operand:ANYF 0 "register_operand" "=f")
+    (fma:ANYF
+      (neg:ANYF (match_operand:ANYF 1 "register_operand" "f"))
+      (match_operand:ANYF 2 "register_operand" "f")
+      (neg:ANYF (match_operand:ANYF 3 "register_operand" "f"))))]
+  "TARGET_HARD_FLOAT"
+  "fnmsub.<fmt>\t%0,%1,%2,%3"
+  [(set_attr "type" "fmadd")
+   (set_attr "mode" "<UNITMODE>")])
+
 (define_insn "nfma<mode>4"
   [(set (match_operand:ANYF 0 "register_operand" "=f")
     (neg:ANYF


### PR DESCRIPTION
 - fnma<mode>4 and fnms<mode>4 is standard pattern and it's describe in
   gcc internal as follow rtl:

    (fma:m (neg:m op1) op2 op3) for fnma<mode>4
    (fma:m (neg:m op1) op2 (neg:m op3)) for fnms<mode>4

 - However we still keep nfma<mode4> and nfms<mode>4 pattern even they
   are not standard pattern name since gcc will try to combine such
   form:

    (neg (fma:m op1 op2 op3))
    (neg (fma:m op1 op2 (neg:m op3)))

 - They are equal, so maybe it's kind of bug in combine pass.