### PR TITLE
Use more conservative fences on RISC-V

### DIFF
--- a/gcc/ChangeLog
+++ b/gcc/ChangeLog
@@ -1,3 +1,10 @@
+2017-03-13  Palmer Dabbelt  <palmer@dabbelt.com
+
+	* config/riscv/riscv.c (riscv_print_operand): Use "fence
+        rwio,wo".
+        * config/riscv/sync.mc (mem_thread_fence_1): Use "fence
+        rwio,rwio".
+
 2017-02-08  Segher Boessenkool  <segher@kernel.crashing.org>
 
 	PR translation/79397

--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -2794,7 +2794,7 @@ riscv_print_operand (FILE *file, rtx op, int letter)
 
     case 'F':
       if (riscv_memmodel_needs_release_fence ((enum memmodel) INTVAL (op)))
-	fputs ("fence rw,w; ", file);
+	fputs ("fence rwio,wo; ", file);
       break;
 
     default:

--- a/gcc/config/riscv/sync.md
+++ b/gcc/config/riscv/sync.md
@@ -53,7 +53,7 @@
 	(unspec:BLK [(match_dup 0)] UNSPEC_MEMORY_BARRIER))
    (match_operand:SI 1 "const_int_operand" "")] ;; model
   ""
-  "fence\trw,rw")
+  "fence\trwio,rwio")
 
 ;; Atomic memory operations.
 

--- a/gcc/testsuite/ChangeLog
+++ b/gcc/testsuite/ChangeLog
@@ -1,3 +1,9 @@
+2017-02-08  Kelvin Nilsen  <kelvin@gcc.gnu.org>
+
+	PR target/68972
+	* g++.dg/cpp1y/vla-initlist1.C: Add dg-skip-if directive to
+	disable this test on power architecture.
+
 2017-02-08  Richard Biener  <rguenther@suse.de>
 
 	PR tree-optimization/71824

--- a/gcc/testsuite/g++.dg/cpp1y/vla-initlist1.C
+++ b/gcc/testsuite/g++.dg/cpp1y/vla-initlist1.C
@@ -1,4 +1,5 @@
 // { dg-do run { target c++11 } }
+// { dg-skip-if "power overwrites two slots of array i" { "power*-*-*" } }
 // { dg-options "-Wno-vla" }
 
 #include <initializer_list>


### PR DESCRIPTION
The RISC-V memory model is still in the process of being formally
specified, so for now we're going to be safe and add the I/O bits to
userspace fences because there's no way to know if userspace is touching
memory-mapped I/O regions at compile time.

This will have no impact on existing microarchitecutres because they
treat all fences conservatively.

gcc/ChangeLog:

        * config/riscv/riscv.c (riscv_print_operand): Use "fence
        rwio,wo".
        * config/riscv/sync.mc (mem_thread_fence_1): Use "fence
        rwio,rwio".