### PR TITLE
RISC-V: Add -mstrict-align option

### DIFF
--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -126,10 +126,11 @@ along with GCC; see the file COPYING3.  If not see
 /* There is no point aligning anything to a rounder boundary than this.  */
 #define BIGGEST_ALIGNMENT 128
 
-/* The user-level ISA permits misaligned accesses, but they may execute
-   extremely slowly and non-atomically.  Some privileged architectures
-   do not permit them at all.  It is best to enforce strict alignment.  */
-#define STRICT_ALIGNMENT 1
+/* The user-level ISA permits unaligned accesses, but they are not required
+   of the privileged architecture.  */
+#define STRICT_ALIGNMENT TARGET_STRICT_ALIGN
+
+#define SLOW_UNALIGNED_ACCESS(MODE, ALIGN) riscv_slow_unaligned_access
 
 /* Define this if you wish to imitate the way many other C compilers
    handle alignment of bitfields and the structures that contain
@@ -864,6 +865,7 @@ while (0)
 #ifndef USED_FOR_TARGET
 extern const enum reg_class riscv_regno_to_class[];
 extern bool riscv_hard_regno_mode_ok[][FIRST_PSEUDO_REGISTER];
+extern bool riscv_slow_unaligned_access;
 #endif
 
 #define ASM_PREFERRED_EH_DATA_FORMAT(CODE,GLOBAL) \

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -84,6 +84,10 @@ mcmodel=
 Target Report RejectNegative Joined Enum(code_model) Var(riscv_cmodel) Init(TARGET_DEFAULT_CMODEL)
 Specify the code model.
 
+mstrict-align
+Target Report Mask(STRICT_ALIGN) Save
+Assume that unaligned memory accesses are disallowed.
+
 Enum
 Name(code_model) Type(enum riscv_code_model)
 Known code models (for use with the -mcmodel= option):


### PR DESCRIPTION
2017-04-30  Andrew Waterman  <andrew@sifive.com>

	* config/riscv/riscv.opt (mstrict-align): New option.
	* config/riscv/riscv.h (STRICT_ALIGNMENT): Use it.  Update comment.
	(SLOW_UNALIGNED_ACCESS): Define.
	(riscv_slow_unaligned_access): Declare.
	* config/riscv/riscv.c (riscv_tune_info): Add slow_unaligned_access
	field.
	(riscv_slow_unaligned_access): New variable.
	(rocket_tune_info): Set slow_unaligned_access to true.
	(optimize_size_tune_info): Set slow_unaligned_access to false.
	(riscv_cpu_info_table): Add entry for optimize_size_tune_info.
	(riscv_valid_lo_sum_p): Use TARGET_STRICT_ALIGN.
	(riscv_option_override): Set riscv_slow_unaligned_access.