### PR TITLE
Don't use slow unaligned accesses in store-merging pass

### DIFF
--- a/gcc/ChangeLog
+++ b/gcc/ChangeLog
@@ -1,3 +1,8 @@
+2017-05-18  Andrew Waterman  <andrew@sifive.com>
+
+	* config/riscv/riscv.c (riscv_option_override): Conditionally set
+	TARGET_STRICT_ALIGN based upon -mtune argument.
+
 2017-05-12  Kito Cheng  <kito.cheng@gmail.com>
 
 	* config/riscv/riscv.c (riscv_legitimize_move): Handle

--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -3799,9 +3799,13 @@ riscv_option_override (void)
 
   /* Use -mtune's setting for slow_unaligned_access, even when optimizing
      for size.  For architectures that trap and emulate unaligned accesses,
-     the performance cost is too great, even for -Os.  */
+     the performance cost is too great, even for -Os.  Similarly, if
+     -m[no-]strict-align is left unspecified, heed -mtune's advice.  */
   riscv_slow_unaligned_access = (cpu->tune_info->slow_unaligned_access
 				 || TARGET_STRICT_ALIGN);
+  if ((target_flags_explicit & MASK_STRICT_ALIGN) == 0
+      && cpu->tune_info->slow_unaligned_access)
+    target_flags |= MASK_STRICT_ALIGN;
 
   /* If the user hasn't specified a branch cost, use the processor's
      default.  */


### PR DESCRIPTION
2017-05-18  Andrew Waterman  <andrew@sifive.com>

	* config/riscv/riscv.c: Include params.h.
	(riscv_option_override): Set PARAM_STORE_MERGING_ALLOW_UNALIGNED.