### PR TITLE
Set SLOW_BYTE_ACCESS=1

### DIFF
--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -656,7 +656,7 @@ typedef struct {
 #define MOVE_MAX UNITS_PER_WORD
 #define MAX_MOVE_MAX 8
 
-#define SLOW_BYTE_ACCESS 0
+#define SLOW_BYTE_ACCESS 1
 
 #define SHIFT_COUNT_TRUNCATED 1
 


### PR DESCRIPTION
https://gcc.gnu.org/ml/gcc/2017-08/msg00202.html

We should make sure this doesn't regress on the test suite before sending upstream.

FYI @michaeljclark 