### PR TITLE
RISC-V: Ignore Custom Extensions

### DIFF
--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -87,7 +87,7 @@ riscv_parse_arch_string (const char *isa, int *flags, location_t loc)
   if (*p == 'c')
     *flags |= MASK_RVC, p++;
 
-  if (*p)
+  if (*p && *p != 'x')
     {
       error_at (loc, "-march=%s: unsupported ISA substring %qs", isa, p);
       return;


### PR DESCRIPTION
The RISC-V ISA allows custom ISA extensions to be defined by users.
These extensions must come after all the standard extensions, and must
start with 'x'.  This patch allows these custom extensions to be passed
via the '-march' flag and ignores them -- we don't plan on supporting
any custom extensions in GCC, so I think that's always the right thing
to do.  These extensions will be passed to the assembler, which is
expected to have either been modified to support the extension or
produce an error.

gcc/ChangeLog

2017-09-01  Palmer Dabbelt  <palmer@dabbelt.com>
            Joel Vandergriendt <vandergriendtjoel@gmail.com>

        * common/config/riscv/riscv-common.c (riscv_parse_arch_string):
        Allow custom extensions via -march.