### PR TITLE
Support -mpreferred-stack-boundary flag

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -217,6 +217,9 @@ struct riscv_cpu_info {
 /* Whether unaligned accesses execute very slowly.  */
 bool riscv_slow_unaligned_access;
 
+/* Stack alignment to assume/maintain.  */
+unsigned riscv_stack_boundary;
+
 /* Which tuning parameters to use.  */
 static const struct riscv_tune_info *tune_info;
 
@@ -3807,6 +3810,20 @@ riscv_option_override (void)
   /* We do not yet support ILP32 on RV64.  */
   if (BITS_PER_WORD != POINTER_SIZE)
     error ("ABI requires -march=rv%d", POINTER_SIZE);
+
+  /* Validate -mpreferred-stack-boundary= value.  */
+  riscv_stack_boundary = ABI_STACK_BOUNDARY;
+  if (riscv_preferred_stack_boundary_arg)
+    {
+      int min = ctz_hwi (MIN_STACK_BOUNDARY / 8);
+      int max = 8;
+
+      if (!IN_RANGE (riscv_preferred_stack_boundary_arg, min, max))
+	error ("-mpreferred-stack-boundary=%d must be between %d and %d",
+	       riscv_preferred_stack_boundary_arg, min, max);
+
+      riscv_stack_boundary = 8 << riscv_preferred_stack_boundary_arg;
+    }
 }
 
 /* Implement TARGET_CONDITIONAL_REGISTER_USAGE.  */

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -123,8 +123,14 @@ along with GCC; see the file COPYING3.  If not see
 /* Allocation boundary (in *bits*) for the code of a function.  */
 #define FUNCTION_BOUNDARY (TARGET_RVC ? 16 : 32)
 
+/* The smallest supported stack boundary the calling convention supports.  */
+#define MIN_STACK_BOUNDARY (TARGET_RVE ? BITS_PER_WORD : 2 * BITS_PER_WORD)
+
+/* The ABI stack alignment.  */
+#define ABI_STACK_BOUNDARY (TARGET_RVE ? BITS_PER_WORD : 128)
+
 /* There is no point aligning anything to a rounder boundary than this.  */
-#define BIGGEST_ALIGNMENT (TARGET_RVE ? 32 : 128)
+#define BIGGEST_ALIGNMENT STACK_BOUNDARY
 
 /* The user-level ISA permits unaligned accesses, but they are not required
    of the privileged architecture.  */
@@ -513,7 +519,7 @@ enum reg_class
    `crtl->outgoing_args_size'.  */
 #define OUTGOING_REG_PARM_STACK_SPACE(FNTYPE) 1
 
-#define STACK_BOUNDARY (TARGET_RVE ? 32 : 128)
+#define STACK_BOUNDARY riscv_stack_boundary
 
 /* Symbolic macros for the registers used to return integer and floating
    point values.  */
@@ -868,6 +874,7 @@ while (0)
 extern const enum reg_class riscv_regno_to_class[];
 extern bool riscv_hard_regno_mode_ok[][FIRST_PSEUDO_REGISTER];
 extern bool riscv_slow_unaligned_access;
+extern unsigned riscv_stack_boundary;
 #endif
 
 #define ASM_PREFERRED_EH_DATA_FORMAT(CODE,GLOBAL) \

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -124,7 +124,7 @@ along with GCC; see the file COPYING3.  If not see
 #define FUNCTION_BOUNDARY (TARGET_RVC ? 16 : 32)
 
 /* There is no point aligning anything to a rounder boundary than this.  */
-#define BIGGEST_ALIGNMENT (TARGET_RVE ? BITS_PER_WORD : (2 * BITS_PER_WORD))
+#define BIGGEST_ALIGNMENT (TARGET_RVE ? 32 : 128)
 
 /* The user-level ISA permits unaligned accesses, but they are not required
    of the privileged architecture.  */
@@ -513,7 +513,7 @@ enum reg_class
    `crtl->outgoing_args_size'.  */
 #define OUTGOING_REG_PARM_STACK_SPACE(FNTYPE) 1
 
-#define STACK_BOUNDARY BIGGEST_ALIGNMENT
+#define STACK_BOUNDARY (TARGET_RVE ? 32 : 128)
 
 /* Symbolic macros for the registers used to return integer and floating
    point values.  */

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -33,6 +33,10 @@ mabi=
 Target Report RejectNegative Joined Enum(abi_type) Var(riscv_abi) Init(ABI_ILP32)
 Specify integer and floating-point calling convention.
 
+mpreferred-stack-boundary=
+Target RejectNegative Joined UInteger Var(riscv_preferred_stack_boundary_arg)
+Attempt to keep stack aligned to this power of 2.
+
 Enum
 Name(abi_type) Type(enum riscv_abi_type)
 Supported ABIs (for use with the -mabi= option):


### PR DESCRIPTION
This supports reducing the stack alignment to 8 bytes for RV32I.