### PR TITLE
Define MUSL_DYNAMIC_LINKER for riscv

### DIFF
--- a/gcc/config/riscv/linux.h
+++ b/gcc/config/riscv/linux.h
@@ -24,6 +24,17 @@ along with GCC; see the file COPYING3.  If not see
 
 #define GLIBC_DYNAMIC_LINKER "/lib/ld-linux-riscv" XLEN_SPEC "-" ABI_SPEC ".so.1"
 
+#define MUSL_ABI_SUFFIX \
+  "%{mabi=ilp32:-sf}" \
+  "%{mabi=ilp32f:-sp}" \
+  "%{mabi=ilp32d:}" \
+  "%{mabi=lp64:-sf}" \
+  "%{mabi=lp64f:-sp}" \
+  "%{mabi=lp64d:}" \
+
+#undef MUSL_DYNAMIC_LINKER
+#define MUSL_DYNAMIC_LINKER "/lib/ld-musl-riscv" XLEN_SPEC MUSL_ABI_SUFFIX ".so.1"
+
 /* Because RISC-V only has word-sized atomics, it requries libatomic where
    others do not.  So link libatomic by default, as needed.  */
 #undef LIB_SPEC


### PR DESCRIPTION
This patch teaches gcc configured with a riscv*linux-musl tuple to correctly set the program interpreter for dynamically linked binaries. gcc already has support for musl-libc and just requires the port to define MUSL_DYNAMIC_LINKER.

This patch uses the same scheme as other ports such that the musl libc program interpreter can co-exist with glibc. i.e. `ld-musl-<arch>-<abi>.so.1` instead of `ld-linux-<arch>-<abi>.so.1`.

Tested with gcc 7.2 using the following bootstrap script and musl-riscv port:

- https://github.com/rv8-io/musl-riscv-toolchain
- https://github.com/lluixhi/musl-riscv

Verify program interpreter using readelf

```
$ readelf -l libc-test-bin/argv.exe 

Elf file type is EXEC (Executable file)
Entry point 0x10440
There are 6 program headers, starting at offset 64

Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  PHDR           0x0000000000000040 0x0000000000010040 0x0000000000010040
                 0x0000000000000150 0x0000000000000150  R E    0x8
  INTERP         0x0000000000000190 0x0000000000010190 0x0000000000010190
                 0x0000000000000020 0x0000000000000020  R      0x1
      [Requesting program interpreter: /lib/ld-musl-riscv64-lp64d.so.1]
  LOAD           0x0000000000000000 0x0000000000010000 0x0000000000010000
                 0x00000000000008cc 0x00000000000008cc  R E    0x1000
  LOAD           0x0000000000000e50 0x0000000000011e50 0x0000000000011e50
                 0x0000000000000200 0x0000000000000240  RW     0x1000
  DYNAMIC        0x0000000000000e60 0x0000000000011e60 0x0000000000011e60
                 0x00000000000001a0 0x00000000000001a0  RW     0x8
  GNU_RELRO      0x0000000000000e50 0x0000000000011e50 0x0000000000011e50
                 0x00000000000001b0 0x00000000000001b0  R      0x1

 Section to Segment mapping:
  Segment Sections...
   00     
   01     .interp 
   02     .interp .hash .dynsym .dynstr .rela.plt .plt .text .rodata .eh_frame 
   03     .init_array .fini_array .dynamic .got .sdata .sbss .bss 
   04     .dynamic 
   05     .init_array .fini_array .dynamic 
```

Testing a dynamic binary compiled with musl-riscv

```
/ # cd /lib
/lib # ls -l
lrwxrwxrwx    1 0        0                7 Sep 23  2017 ld-musl-riscv64-lp64d.so.1 -> libc.so
-rwxr-xr-x    1 0        0           796648 Sep 23  2017 libc.so
/lib # cd /tmp
/tmp # tar xf libc-test-bin.tar 
/tmp # cd libc-test-bin/
/tmp/libc-test-bin # ./argv.exe
/tmp/libc-test-bin # uname -a
Linux ucbvax 4.6.2-g250754b #4 Sun Sep 24 12:05:47 NZDT 2017 riscv64 GNU/Linux
```