### PR TITLE
Allow use of fs0-fs11 as call-clobbered registers in soft-float ABI

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -4002,6 +4002,13 @@ riscv_conditional_register_usage (void)
       for (int regno = FP_REG_FIRST; regno <= FP_REG_LAST; regno++)
 	fixed_regs[regno] = call_used_regs[regno] = 1;
     }
+
+  /* In the soft-float ABI, there are no callee-saved FP registers.  */
+  if (UNITS_PER_FP_ARG == 0)
+    {
+      for (int regno = FP_REG_FIRST; regno <= FP_REG_LAST; regno++)
+	call_used_regs[regno] = 1;
+    }
 }
 
 /* Return a register priority for hard reg REGNO.  */


### PR DESCRIPTION
Note this change does not cause ABI breakage, because previously we had disallowed use of fs0-fs11 altogether in the soft-float ABI.