### PR TITLE
Mark integer library routines as functions

### DIFF
--- a/libgcc/ChangeLog
+++ b/libgcc/ChangeLog
@@ -1,3 +1,9 @@
+2017-11-04  Chih-Mao Chen <pkmx.tw@gmail.com>
+
+	* config/riscv/div.S: Set symbol type to function.
+	* config/riscv/muldi3.S: Likewise.
+	* config/riscv/multi3.S: Likewise.
+
 2017-05-02  Release Manager
 
 	* GCC 7.1.0 released.

--- a/libgcc/config/riscv/div.S
+++ b/libgcc/config/riscv/div.S
@@ -34,6 +34,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 # define __moddi3 __modsi3
 #else
   .globl __udivsi3
+  .type  __udivsi3, @function
 __udivsi3:
   /* Compute __udivdi3(a0 << 32, a1 << 32); cast result to uint32_t.  */
   sll    a0, a0, 32
@@ -44,6 +45,7 @@ __udivsi3:
   jr     t0
 
   .globl __umodsi3
+  .type  __umodsi3, @function
 __umodsi3:
   /* Compute __udivdi3((uint32_t)a0, (uint32_t)a1); cast a1 to uint32_t.  */
   sll    a0, a0, 32
@@ -56,9 +58,11 @@ __umodsi3:
   jr     t0
 
   .globl __modsi3
+  .type  __modsi3, @function
   __modsi3 = __moddi3
 
   .globl __divsi3
+  .type  __divsi3, @function
 __divsi3:
   /* Check for special case of INT_MIN/-1. Otherwise, fall into __divdi3.  */
   li    t0, -1
@@ -66,12 +70,14 @@ __divsi3:
 #endif
 
   .globl __divdi3
+  .type  __divdi3, @function
 __divdi3:
   bltz  a0, .L10
   bltz  a1, .L11
   /* Since the quotient is positive, fall into __udivdi3.  */
 
   .globl __udivdi3
+  .type  __udivdi3, @function
 __udivdi3:
   mv    a2, a1
   mv    a1, a0
@@ -98,6 +104,7 @@ __udivdi3:
   ret
 
   .globl __umoddi3
+  .type  __umoddi3, @function
 __umoddi3:
   /* Call __udivdi3(a0, a1), then return the remainder, which is in a1.  */
   move  t0, ra
@@ -120,6 +127,7 @@ __umoddi3:
   jr    t0
 
   .globl __moddi3
+  .type  __moddi3, @function
 __moddi3:
   move   t0, ra
   bltz   a1, .L31

--- a/libgcc/config/riscv/muldi3.S
+++ b/libgcc/config/riscv/muldi3.S
@@ -32,6 +32,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #endif
 
   .globl __muldi3
+  .type  __muldi3, @function
 __muldi3:
   mv     a2, a0
   li     a0, 0

--- a/libgcc/config/riscv/multi3.S
+++ b/libgcc/config/riscv/multi3.S
@@ -32,6 +32,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #endif
 
   .globl __multi3
+  .type  __multi3, @function
 __multi3:
 
 #if __riscv_xlen == 32


### PR DESCRIPTION
Currently you can't link those in `libgcc_s.so`:

```c
unsigned udivsi3(unsigned a, unsigned b) {
    return a / b;
}

int main(void) {
    return 0;
}
```

```
$ riscv32-unknown-linux-gnu-gcc -march=rv32i -shared-libgcc main.c
ld: warning: type and size of dynamic symbol `__udivsi3@@GCC_3.0' are not defined
```

This patch marks them as functions so the linker knows that it should create a PLT entry.