### PR TITLE
RISC-V: Define _REENTRANT if -pthread is given

### DIFF
--- a/gcc/config/riscv/linux.h
+++ b/gcc/config/riscv/linux.h
@@ -55,3 +55,5 @@ along with GCC; see the file COPYING3.  If not see
       %{rdynamic:-export-dynamic} \
       -dynamic-linker " GNU_USER_DYNAMIC_LINKER "} \
     %{static:-static}}"
+
+#define CPP_SPEC "%{pthread:-D_REENTRANT}"


### PR DESCRIPTION
 - AX_PTHREAD (provide by ax_pthread.m4) will check this marco is
   define or not for check pthread is available or not.
   - https://savannah.gnu.org/patch/?8186
   - https://www.gnu.org/software/autoconf-archive/ax_pthread.html

 - Most of all other target will do the same thing in their linux
   port, e.g. ARM, AArch64, i386, mips...