### PR TITLE
RISC-V: wchar_t should be unsigned

### DIFF
--- a/gcc/config/riscv/linux.h
+++ b/gcc/config/riscv/linux.h
@@ -53,3 +53,7 @@ along with GCC; see the file COPYING3.  If not see
       %{rdynamic:-export-dynamic} \
       -dynamic-linker " GNU_USER_DYNAMIC_LINKER "} \
     %{static:-static}}"
+
+/* Defined by the ABI */
+#define WCHAR_TYPE			"unsigned int"
+#define WCHAR_TYPE_SIZE                 32


### PR DESCRIPTION
Michael Clark found that we have an unsigned char by default, but that
we have a signed wchar_t.  It seems somewhat illogical to mix these.
This was previously undefined in our ABI document, so we've recently
defined wchar_t to be 32-bit and unsigned.  Thus, we're calling the old
behavior an ABI bug and updating this.

Note that our Linux port isn't upstream yet, so technically the full ABI
isn't set in stone.  We've been trying our best to avoid any changes to
the ABI as it stands in GCC, but I think this is esoteric enough to
change.

gcc/ChangeLog

2017-11-08  Palmer Dabbelt  <palmer@sifive.com>
            Michael Clark <michaeljclark@mac.com>

        * config/riscv/linux.h (WCHAR_TYPE): New define.
        (WCHAR_TYPE_SIZE): Likewise.