### PR TITLE
Rewrite multi3.c with faster implementation.

### DIFF
--- a/libgcc/config/riscv/multi3.c
+++ b/libgcc/config/riscv/multi3.c
@@ -1,3 +1,28 @@
+/* Multiplication two double word integers for RISC-V.
+
+   Copyright (C) 2016-2017 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+Under Section 7 of GPL version 3, you are granted additional
+permissions described in the GCC Runtime Library Exception, version
+3.1, as published by the Free Software Foundation.
+
+You should have received a copy of the GNU General Public License and
+a copy of the GCC Runtime Library Exception along with this program;
+see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+<http://www.gnu.org/licenses/>.  */
+
 #include "tconfig.h"
 #include "tsystem.h"
 #include "coretypes.h"
@@ -8,7 +33,8 @@
 #include "libgcc2.h"
 
 #if __riscv_xlen == 32
-  #define __multi3 __muldi3
+/* Our RV64 64-bit routines are equivalent to our RV32 32-bit routines.  */
+# define __multi3 __muldi3
 #endif
 
 DWtype
@@ -16,10 +42,45 @@ __multi3 (DWtype u, DWtype v)
 {
   const DWunion uu = {.ll = u};
   const DWunion vv = {.ll = v};
-  DWunion w = {.ll = __umulsidi3 (uu.s.low, vv.s.low)};
+  DWunion w;
+  UWtype u_low = uu.s.low;
+  UWtype v_low = vv.s.low;
+  UWtype u_low_msb;
+  UWtype w_low = 0;
+  UWtype new_w_low;
+  UWtype w_high = 0;
+  UWtype w_high_tmp = 0;
+  UWtype w_high_tmp2x;
+  UWtype carry;
 
-  w.s.high += (__muluw3((UWtype) uu.s.low, (UWtype) vv.s.high)
-               + __muluw3((UWtype) uu.s.high, (UWtype) vv.s.low));
+  /* Calculate low half part of u and v, and get a UDWtype result just like
+     what __umulsidi3 do.  */
+  do
+    {
+      new_w_low = w_low + u_low;
+      w_high_tmp2x = w_high_tmp << 1;
+      w_high_tmp += w_high;
+      if (v_low & 1)
+	{
+	  carry = new_w_low < w_low;
+	  w_low = new_w_low;
+	  w_high = carry + w_high_tmp;
+	}
+      u_low_msb = (u_low >> ((sizeof (UWtype) * 8) - 1));
+      v_low >>= 1;
+      u_low <<= 1;
+      w_high_tmp = u_low_msb | w_high_tmp2x;
+    }
+  while (v_low);
+
+  w.s.low = w_low;
+  w.s.high = w_high;
+
+  if (uu.s.high)
+    w.s.high = w.s.high + __muluw3(vv.s.low, uu.s.high);
+
+  if (vv.s.high)
+    w.s.high += __muluw3(uu.s.low, vv.s.high);
 
   return w.ll;
 }


### PR DESCRIPTION
I've tested with gcc testsuite, supertest and plumhall, this version is little better than the old `multi3.s` since gcc hoisted some code inside if-block, and gcc generated almost same code quality for rv32e :)