### PR TITLE
Use __riscv_flush_icache to flush the I$ on Linux

### DIFF
--- a/gcc/config/riscv/linux.h
+++ b/gcc/config/riscv/linux.h
@@ -45,6 +45,8 @@ along with GCC; see the file COPYING3.  If not see
 #define LIB_SPEC GNU_USER_TARGET_LIB_SPEC " -latomic "
 #endif
 
+#define ICACHE_FLUSH_FUNC "__riscv_flush_icache"
+
 #define LINK_SPEC "\
 -melf" XLEN_SPEC "lriscv \
 %{shared} \

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1455,7 +1455,13 @@
    (match_operand 1 "pmode_register_operand")]
   ""
 {
+#ifdef ICACHE_FLUSH_FUNC
+  emit_library_call (gen_rtx_SYMBOL_REF (Pmode, ICACHE_FLUSH_FUNC),
+		     LCT_NORMAL, VOIDmode, 3, operands[0], Pmode,
+		     operands[1], Pmode, const0_rtx, Pmode);
+#else
   emit_insn (gen_fence_i ());
+#endif
   DONE;
 })
 


### PR DESCRIPTION
The fence.i instruction is not appropriate, because it only flushes
the current core's I$.  If the thread is migrated to a different core,
the instructions would be incoherent.

This depends on https://github.com/riscv/riscv-glibc/pull/22