### PR TITLE
RISC-V: Fix save-restore with leaf function.

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -125,9 +125,6 @@ struct GTY(())  machine_function {
      This area is allocated by the callee at the very top of the frame.  */
   int varargs_size;
 
-  /* Memoized return value of leaf_function_p.  <0 if false, >0 if true.  */
-  int is_leaf;
-
   /* The current frame information, calculated by riscv_compute_frame_info.  */
   struct riscv_frame_info frame;
 };
@@ -4200,26 +4197,15 @@ riscv_trampoline_init (rtx m_tramp, tree fndecl, rtx chain_value)
   emit_insn (gen_clear_cache (addr, end_addr));
 }
 
-/* Return leaf_function_p () and memoize the result.  */
-
-static bool
-riscv_leaf_function_p (void)
-{
-  if (cfun->machine->is_leaf == 0)
-    cfun->machine->is_leaf = leaf_function_p () ? 1 : -1;
-
-  return cfun->machine->is_leaf > 0;
-}
-
 /* Implement TARGET_FUNCTION_OK_FOR_SIBCALL.  */
 
 static bool
 riscv_function_ok_for_sibcall (tree decl ATTRIBUTE_UNUSED,
 			       tree exp ATTRIBUTE_UNUSED)
 {
-  /* When optimzing for size, don't use sibcalls in non-leaf routines */
+  /* Don't use sibcalls when use save-restore routine.  */
   if (TARGET_SAVE_RESTORE)
-    return riscv_leaf_function_p ();
+    return false;
 
   return true;
 }

--- a/gcc/testsuite/gcc.target/riscv/riscv.exp
+++ b/gcc/testsuite/gcc.target/riscv/riscv.exp
@@ -1,0 +1,41 @@
+# Copyright (C) 2017 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+# GCC testsuite that uses the `dg.exp' driver.
+
+# Exit immediately if this isn't a RISC-V target.
+if ![istarget riscv*-*-*] then {
+  return
+}
+
+# Load support procs.
+load_lib gcc-dg.exp
+
+# If a testcase doesn't have special options, use these.
+global DEFAULT_CFLAGS
+if ![info exists DEFAULT_CFLAGS] then {
+    set DEFAULT_CFLAGS " -ansi -pedantic-errors"
+}
+
+# Initialize `dg'.
+dg-init
+
+# Main loop.
+dg-runtest [lsort [glob -nocomplain $srcdir/$subdir/*.\[cS\]]] \
+	"" $DEFAULT_CFLAGS
+
+# All done.
+dg-finish

--- a/gcc/testsuite/gcc.target/riscv/save-restore-1.c
+++ b/gcc/testsuite/gcc.target/riscv/save-restore-1.c
@@ -1,0 +1,25 @@
+/* { dg-do run } */
+/* { dg-options "-O2 -msave-restore -fomit-frame-pointer" } */
+
+#include <stdlib.h>
+
+__attribute__((noinline)) int g(void) { return 42; }
+
+__attribute__((noinline)) int f(void) {
+  asm volatile ("li s0, 0x87654321" ::: "s0");
+  return g();
+}
+
+int main(void) {
+  asm volatile ("li s0, 0x12345678" ::: "s0");
+
+  f();
+
+  long s0;
+  asm volatile ("mv %0, s0" : "=r"(s0));
+
+  if (s0 == 0x12345678)
+    exit (0);
+  else
+    abort();
+}


### PR DESCRIPTION
This PR fixed #115, here is not only one solution for that, but we decide to disable sibcall in epilogue is prologue already generated save routine, since its can minimize code change.

I think here is another solution is fix offset of the callee-save register in epilogue when riscv_expand_prologue called with sibcall=true, but it'll make the code gen logic more complicate.

```
gcc/ChangeLog

2017-12-29  Monk Chiang  <sh.chiang04@gmail.com>
	    Kito Cheng  <kito.cheng@gmail.com>

	* config/riscv/riscv.c (machine_function::is_leaf): Remove
	  field.
	  (machine_function::saved_libcall): New field.
	  (riscv_expand_prologue): Set machine_function::saved_libcall.
	  (riscv_leaf_function_p): Delete.
	  (riscv_function_ok_for_sibcall): Use
	  machine_function::saved_libcall instead of
	  machine_function::is_leaf to check sibcall is ok.

gcc/testsuite/ChangeLog

2017-12-29  Chih-Mao Chen <pkmx.tw@gmail.com>
	    Monk Chiang  <sh.chiang04@gmail.com>

	* gcc.target/riscv/riscv.exp: New file.
	* gcc.target/riscv/save-restore-1.c: New test.
```