### PR TITLE
[WIP]: Disable TLS copy relocs.

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -1209,9 +1209,11 @@ riscv_legitimize_tls_address (rtx loc)
   rtx dest, tp, tmp;
   enum tls_model model = SYMBOL_REF_TLS_MODEL (loc);
 
+#if 0
   /* Since we support TLS copy relocs, non-PIC TLS accesses may all use LE.  */
   if (!flag_pic)
     model = TLS_MODEL_LOCAL_EXEC;
+#endif
 
   switch (model)
     {


### PR DESCRIPTION
	* config/riscv/riscv.c (riscv_legitimize_tls_address): Ifdef out
	code to force TLS_MODEL_LOCAL_EXEC when !flag_pic.