### PR TITLE
Raise error on unexpected ISA string at end

### DIFF
--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -513,6 +513,13 @@ riscv_subset_list::parse (const char *arch, location_t loc)
   if (p == NULL)
     goto fail;
 
+  if (*p != '\0')
+    {
+      error_at (loc, "-march=%s: unexpected ISA string at end: %<%s%>",
+               arch, p);
+      return NULL;
+    }
+
   return subset_list;
 
 fail:

--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -517,7 +517,7 @@ riscv_subset_list::parse (const char *arch, location_t loc)
     {
       error_at (loc, "-march=%s: unexpected ISA string at end: %<%s%>",
                arch, p);
-      return NULL;
+      goto fail;
     }
 
   return subset_list;

--- a/gcc/testsuite/gcc.target/riscv/attribute-10.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-10.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -march=rv32im_s_sx_unexpectedstring -mabi=ilp32" } */
+int foo()
+{
+}
+/* { dg-error "unexpected ISA string at end:" "" { target { "riscv*-*-*" } } 0 } */


### PR DESCRIPTION
Hi all, this patch backports the error handling code from binutils-gdb.

Raise an error when the user inputs an unexpected arch string past the expected end, rather than silently pruning the arch string.
