### PR TITLE
Add canonical parsing of zbX -march flags

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -34,42 +34,42 @@
 (define_insn "clzsi2"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(clz:SI (match_operand:SI 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB"
   { return TARGET_64BIT ? "clzw\t%0,%1" : "clz\t%0,%1"; }
   [(set_attr "type" "bitmanip")])
 
 (define_insn "clzdi2"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(clz:DI (match_operand:DI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "clz\t%0,%1"
   [(set_attr "type" "bitmanip")])
 
 (define_insn "ctzsi2"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(ctz:SI (match_operand:SI 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB"
   { return TARGET_64BIT ? "ctzw\t%0,%1" : "ctz\t%0,%1"; }
   [(set_attr "type" "bitmanip")])
 
 (define_insn "ctzdi2"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(ctz:DI (match_operand:DI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "ctz\t%0,%1"
   [(set_attr "type" "bitmanip")])
 
 (define_insn "popcountsi2"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(popcount:SI (match_operand:SI 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB"
   { return TARGET_64BIT ? "pcntw\t%0,%1" : "pcnt\t%0,%1"; }
   [(set_attr "type" "bitmanip")])
 
 (define_insn "popcountdi2"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(popcount:DI (match_operand:DI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "pcnt\t%0,%1"
   [(set_attr "type" "bitmanip")])
 
@@ -77,7 +77,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(bitmanip_bitwise:X (not:X (match_operand:X 1 "register_operand" "r"))
 			    (match_operand:X 2 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB || TARGET_ZBP"
   "<insn>n\t%0,%2,%1"
   [(set_attr "type" "bitmanip")])
 
@@ -85,7 +85,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(not:X (xor:X (match_operand:X 1 "register_operand" "r")
 		      (match_operand:X 2 "register_operand" "r"))))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB || TARGET_ZBP"
   "xnor\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
  
@@ -95,7 +95,7 @@
 (define_insn "*zero_extendhi<GPR:mode>2_bitmanip"
   [(set (match_operand:GPR 0 "register_operand" "=r,r")
 	(zero_extend:GPR (match_operand:HI 1 "nonimmediate_operand" "r,m")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB || TARGET_ZBP"
 {
   if (which_alternative == 0)
    return TARGET_64BIT ? "packw\t%0,%1,x0" : "pack\t%0,%1,x0";
@@ -108,7 +108,7 @@
 (define_insn "*zero_extendsidi2_bitmanip"
   [(set (match_operand:DI 0 "register_operand" "=r,r")
 	(zero_extend:DI (match_operand:SI 1 "nonimmediate_operand" "r,m")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && (TARGET_ZBB || TARGET_ZBP)"
   "@
    pack\t%0,%1,x0
    lwu\t%0,%1"
@@ -118,7 +118,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(any_minmax:X (match_operand:X 1 "register_operand" "r")
 		      (match_operand:X 2 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB"
   "<bitmanip_insn>\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -129,7 +129,7 @@
 	(ior:X (ashift:X (const_int 1)
 			 (match_operand:QI 2 "register_operand" "=r"))
 	       (match_operand:X 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbset\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -137,7 +137,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(ior:X (match_operand:X 1 "register_operand" "r")
 	       (match_operand 2 "single_bit_mask_operand" "i")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbseti\t%0,%1,%S2"
   [(set_attr "type" "bitmanip")])
 
@@ -149,7 +149,7 @@
 		   (ashift:SI (const_int 1)
 			      (match_operand:QI 2 "register_operand" "=r")) 0)
 		  (match_operand:DI 1 "register_operand" "r")) 0)))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbsetw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -158,7 +158,7 @@
 	(and:X (rotate:X (const_int -2)
 			 (match_operand:QI 2 "register_operand" "=r"))
 	       (match_operand:X 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbclr\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -166,7 +166,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(and:X (match_operand:X 1 "register_operand" "r")
 	       (match_operand 2 "not_single_bit_mask_operand" "i")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbclri\t%0,%1,%T2"
   [(set_attr "type" "bitmanip")])
 
@@ -179,7 +179,7 @@
 		    (ashift:SI (const_int 1)
 			       (match_operand:QI 2 "register_operand" "=r")) 0))
 	   (match_operand:DI 1 "register_operand" "r")) 0)))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbclrw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -188,7 +188,7 @@
 	(xor:X (ashift:X (const_int 1)
 			 (match_operand:QI 2 "register_operand" "=r"))
 	       (match_operand:X 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbinv\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -196,7 +196,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(xor:X (match_operand:X 1 "register_operand" "r")
 	       (match_operand 2 "single_bit_mask_operand" "i")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbinvi\t%0,%1,%S2"
   [(set_attr "type" "bitmanip")])
 
@@ -208,7 +208,7 @@
 		   (ashift:SI (const_int 1)
 			      (match_operand:QI 2 "register_operand" "=r")) 0)
 		  (match_operand:DI 1 "register_operand" "r")) 0)))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbinvw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -218,7 +218,7 @@
 			(const_int 1)
 			(zero_extend:X
 			 (match_operand:QI 2 "register_operand" "r"))))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbext\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -227,7 +227,7 @@
 	(zero_extract:X (match_operand:X 1 "register_operand" "r")
 			(const_int 1)
 			(match_operand 2 "immediate_operand" "i")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbexti\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -238,7 +238,7 @@
 	  (lshiftrt:SI (match_operand:SI 1 "register_operand" "r")
 		       (match_operand:QI 2 "register_operand" "r")) 0)
 	 (const_int 1)))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbextw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -248,7 +248,7 @@
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(rotatert:SI (match_operand:SI 1 "register_operand" "r")
 		     (match_operand:SI 2 "arith_operand" "rI")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB || TARGET_ZBP"
   { return TARGET_64BIT ? "ror%i2w\t%0,%1,%2" : "ror%i2\t%0,%1,%2"; }
   [(set_attr "type" "bitmanip")])
 
@@ -256,7 +256,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(rotatert:DI (match_operand:DI 1 "register_operand" "r")
 		     (match_operand:DI 2 "arith_operand" "rI")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && (TARGET_ZBB || TARGET_ZBP)"
   "ror%i2\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -274,7 +274,7 @@
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(rotate:SI (match_operand:SI 1 "register_operand" "r")
 		   (match_operand:SI 2 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB || TARGET_ZBP"
   { return TARGET_64BIT ? "rolw\t%0,%1,%2" : "rol\t%0,%1,%2"; }
   [(set_attr "type" "bitmanip")])
 
@@ -282,7 +282,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(rotate:DI (match_operand:DI 1 "register_operand" "r")
 		   (match_operand:DI 2 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_64BIT && (TARGET_ZBB || TARGET_ZBP)"
   "rol\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -300,7 +300,7 @@
 (define_insn "bswapsi2"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(bswap:SI (match_operand:SI 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBP"
   { return TARGET_64BIT ? "greviw\t%0,%1,0x18" : "grevi\t%0,%1,0x18"; }
   [(set_attr "type" "bitmanip")])
 
@@ -308,7 +308,7 @@
 (define_insn "bswapdi2"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(bswap:SI (match_operand:SI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBP"
   "grevi\t%0,%1,0x38"
   [(set_attr "type" "bitmanip")])
 
@@ -328,7 +328,7 @@
 			     (match_operand:X 3 "register_operand" "r"))
 		      (match_operand:X 2 "register_operand" "r"))
 	       (match_dup 3)))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBT"
   "cmix\t%0,%2,%1,%3"
   [(set_attr "type" "bitmanip")])
 
@@ -340,7 +340,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(zero_extend:DI (plus:SI (match_operand:SI 1 "register_operand" "r")
 				 (match_operand:SI 2 "arith_operand" "rI"))))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "add%i2wu\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -348,7 +348,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(zero_extend:DI (minus:SI (match_operand:SI 1 "register_operand" "r")
 				  (match_operand:SI 2 "register_operand" "r"))))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "subwu\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -357,7 +357,7 @@
 	(plus:DI (zero_extend:DI
 		  (subreg:SI (match_operand:DI 2 "register_operand" "r") 0))
 		 (match_operand:DI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "addu.w\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -366,7 +366,7 @@
 	(minus:DI (match_operand:DI 1 "register_operand" "r")
 		  (zero_extend:DI
 		   (subreg:SI (match_operand:DI 2 "register_operand" "r") 0))))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "subu.w\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -375,7 +375,7 @@
 	(and:DI (ashift:DI (match_operand:DI 1 "register_operand" "r")
 			   (match_operand:QI 2 "immediate_operand" "I"))
 		(match_operand 3 "immediate_operand" "")))]
-  "TARGET_64BIT && TARGET_BITMANIP
+  "TARGET_64BIT && TARGET_ZBB
    && (INTVAL (operands[3]) >> INTVAL (operands[2])) == 0xffffffff"
   "slliu.w\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])

--- a/gcc/config/riscv/riscv-opts.h
+++ b/gcc/config/riscv/riscv-opts.h
@@ -51,4 +51,54 @@ enum riscv_align_data {
   riscv_align_data_type_natural
 };
 
+/* Define subset flag positions. Alphabetical order is important.
+   I've left the "OPTION_MASK_" prefixes in the hope that these
+   can be moved to riscv.opt at some point. */
+
+/* Flags for the general extension subsets. */
+#define OPTION_MASK_ZAM (1 << 0)
+#define OPTION_MASK_ZIFENCEI (1 << 1)
+#define OPTION_MASK_ZTSO (1 << 2)
+
+/* Flags for the Bitmanip extension subsets. */
+#define OPTION_MASK_ZBB (1 << 0)
+#define OPTION_MASK_ZBC (1 << 1)
+#define OPTION_MASK_ZBE (1 << 2)
+#define OPTION_MASK_ZBF (1 << 3)
+#define OPTION_MASK_ZBM (1 << 4)
+#define OPTION_MASK_ZBP (1 << 5)
+#define OPTION_MASK_ZBR (1 << 6)
+#define OPTION_MASK_ZBS (1 << 7)
+#define OPTION_MASK_ZBT (1 << 8)
+
+/* Flag predicates for the general extension subsets. */
+#define TARGET_ZAM ((riscv_subset_flags & OPTION_MASK_ZAM) != 0)
+#define TARGET_ZAM_P(riscv_subset_flags) (((riscv_subset_flags) & OPTION_MASK_ZAM) != 0)
+
+#define TARGET_ZIFENCEI ((riscv_subset_flags & OPTION_MASK_ZIFENCEI) != 0)
+#define TARGET_ZIFENCEI_P(riscv_subset_flags) (((riscv_subset_flags) & OPTION_MASK_ZIFENCEI) != 0)
+
+#define TARGET_ZTSO ((riscv_subset_flags & OPTION_MASK_ZTSO) != 0)
+#define TARGET_ZTSO_P(riscv_subset_flags) (((riscv_subset_flags) & OPTION_MASK_ZTSO) != 0)
+
+/* Flag predicates for the bitmanip extension subsets. */
+#define TARGET_ZBB ((riscv_bitmanip_subset_flags & OPTION_MASK_ZBB) != 0)
+#define TARGET_ZBB_P(riscv_bitmanip_subset_flags) (((riscv_bitmanip_subset_flags) & OPTION_MASK_ZBB) != 0)
+#define TARGET_ZBC ((riscv_bitmanip_subset_flags & OPTION_MASK_ZBC) != 0)
+#define TARGET_ZBC_P(riscv_bitmanip_subset_flags) (((riscv_bitmanip_subset_flags) & OPTION_MASK_ZBC) != 0)
+#define TARGET_ZBE ((riscv_bitmanip_subset_flags & OPTION_MASK_ZBE) != 0)
+#define TARGET_ZBE_P(riscv_bitmanip_subset_flags) (((riscv_bitmanip_subset_flags) & OPTION_MASK_ZBE) != 0)
+#define TARGET_ZBF ((riscv_bitmanip_subset_flags & OPTION_MASK_ZBF) != 0)
+#define TARGET_ZBF_P(riscv_bitmanip_subset_flags) (((riscv_bitmanip_subset_flags) & OPTION_MASK_ZBF) != 0)
+#define TARGET_ZBM ((riscv_bitmanip_subset_flags & OPTION_MASK_ZBM) != 0)
+#define TARGET_ZBM_P(riscv_bitmanip_subset_flags) (((riscv_bitmanip_subset_flags) & OPTION_MASK_ZBM) != 0)
+#define TARGET_ZBP ((riscv_bitmanip_subset_flags & OPTION_MASK_ZBP) != 0)
+#define TARGET_ZBP_P(riscv_bitmanip_subset_flags) (((riscv_bitmanip_subset_flags) & OPTION_MASK_ZBP) != 0)
+#define TARGET_ZBR ((riscv_bitmanip_subset_flags & OPTION_MASK_ZBR) != 0)
+#define TARGET_ZBR_P(riscv_bitmanip_subset_flags) (((riscv_bitmanip_subset_flags) & OPTION_MASK_ZBR) != 0)
+#define TARGET_ZBS ((riscv_bitmanip_subset_flags & OPTION_MASK_ZBS) != 0)
+#define TARGET_ZBS_P(riscv_bitmanip_subset_flags) (((riscv_bitmanip_subset_flags) & OPTION_MASK_ZBS) != 0)
+#define TARGET_ZBT ((riscv_bitmanip_subset_flags & OPTION_MASK_ZBT) != 0)
+#define TARGET_ZBT_P(riscv_bitmanip_subset_flags) (((riscv_bitmanip_subset_flags) & OPTION_MASK_ZBT) != 0)
+
 #endif /* ! GCC_RISCV_OPTS_H */

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1055,7 +1055,7 @@
   [(set (match_operand:DI     0 "register_operand"     "=r,r")
 	(zero_extend:DI
 	    (match_operand:SI 1 "nonimmediate_operand" " r,m")))]
-  "TARGET_64BIT && !TARGET_BITMANIP"
+  "TARGET_64BIT && !(TARGET_ZBB || TARGET_ZBP)"
   "@
    #
    lwu\t%0,%1"
@@ -1078,7 +1078,7 @@
   [(set (match_operand:GPR    0 "register_operand"     "=r,r")
 	(zero_extend:GPR
 	    (match_operand:HI 1 "nonimmediate_operand" " r,m")))]
-  "!TARGET_BITMANIP"
+  "!(TARGET_ZBB || TARGET_ZBP)"
   "@
    #
    lhu\t%0,%1"

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -21,6 +21,12 @@
 HeaderInclude
 config/riscv/riscv-opts.h
 
+Variable
+HOST_WIDE_INT riscv_subset_flags = 0
+
+Variable
+HOST_WIDE_INT riscv_bitmanip_subset_flags = 0
+
 mbranch-cost=
 Target RejectNegative Joined UInteger Var(riscv_branch_cost)
 -mbranch-cost=N	Set the cost of branches to roughly N instructions.


### PR DESCRIPTION
Hi all,

This patch adds "-march=rv32imb_[zb*]*" type parsing. It mirrors my pull request in riscv-binutils-gdb/riscv-bitmanip in terms of functionality.

I have classified each instruction, and the "zbx" selectively enables the corresponding groups. The 'b' flag still exists, though. I had a good reason for leaving it in, but I don't remember it anymore... 

All flags are additive.

There are doubtless some bits I forgot to update or re-classify.
