### PR TITLE
Add intrinsics function for rolw

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -260,6 +260,16 @@
   "ror%i2\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
+(define_expand "riscv_rolw"
+  [(match_operand:SI 0 "register_operand" "=r")
+   (match_operand:SI 1 "register_operand" "r")
+   (match_operand:SI 2 "register_operand" "r")]
+  "TARGET_BITMANIP && TARGET_64BIT"
+{
+  emit_insn (gen_rotlsi3 (operands[0], operands[1], operands[2]));
+  DONE;
+})
+
 (define_insn "rotlsi3"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(rotate:SI (match_operand:SI 1 "register_operand" "r")
@@ -274,6 +284,14 @@
 		   (match_operand:DI 2 "register_operand" "r")))]
   "TARGET_BITMANIP"
   "rol\t%0,%1,%2"
+  [(set_attr "type" "bitmanip")])
+
+(define_insn "rotlsi3_sext"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+	(sign_extend:DI (rotate:SI (match_operand:SI 1 "register_operand" "r")
+				   (match_operand:SI 2 "register_operand" "r"))))]
+  "TARGET_BITMANIP"
+  "rolw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
 ;;; ??? grev

--- a/gcc/config/riscv/riscv-builtins.c
+++ b/gcc/config/riscv/riscv-builtins.c
@@ -39,6 +39,7 @@ along with GCC; see the file COPYING3.  If not see
 
 /* Macros to create an enumeration identifier for a function prototype.  */
 #define RISCV_FTYPE_NAME1(A, B) RISCV_##A##_FTYPE_##B
+#define RISCV_FTYPE_NAME2(A, B, C) RISCV_##A##_FTYPE_##B##_##C
 
 /* Classifies the prototype of a built-in function.  */
 enum riscv_function_type {
@@ -126,8 +127,12 @@ AVAIL (hard_float, TARGET_HARD_FLOAT)
 #define RISCV_FTYPE_ATYPES1(A, B) \
   RISCV_ATYPE_##A, RISCV_ATYPE_##B
 
+#define RISCV_FTYPE_ATYPES2(A, B, C) \
+  RISCV_ATYPE_##A, RISCV_ATYPE_##B, RISCV_ATYPE_##C
+
 static const struct riscv_builtin_description riscv_builtins[] = {
   DIRECT_BUILTIN (pcntw, RISCV_SI_FTYPE_SI, bitmanip64),
+  DIRECT_BUILTIN (rolw, RISCV_SI_FTYPE_SI_SI, bitmanip64),
   DIRECT_BUILTIN (frflags, RISCV_USI_FTYPE_VOID, hard_float),
   DIRECT_NO_TARGET_BUILTIN (fsflags, RISCV_VOID_FTYPE_USI, hard_float)
 };

--- a/gcc/config/riscv/riscv-ftypes.def
+++ b/gcc/config/riscv/riscv-ftypes.def
@@ -29,3 +29,4 @@ along with GCC; see the file COPYING3.  If not see
 DEF_RISCV_FTYPE (1, (USI, VOID))
 DEF_RISCV_FTYPE (1, (VOID, USI))
 DEF_RISCV_FTYPE (1, (SI, SI))
+DEF_RISCV_FTYPE (2, (SI, SI, SI))


### PR DESCRIPTION
Just a proof of concept, I didn't run the testsuite or any serious testing.
```
$ cat x.c
#include <rvintrin.h>

int rolw(int a, int b){
  return _rv32_rol(a, b);
}
int rolw_bi(int a, int b){
  return __builtin_riscv_rolw(a, b);
}

$ riscv64-unknown-elf-gcc x.c -S -o - -O3 -fdump-tree-all -march=rv64ib -mabi=lp64
...
rolw:
 #APP
# 137 "/scratch/kitoc/riscv-gnu-workspace/riscv-gnu-toolchain-b-ext/build/install/lib/gcc/riscv64-unknown-elf/10.0.0/include/rvintrin.h" 1
        rolw    a0, a0, a1
# 0 "" 2
 #NO_APP
        sext.w  a0,a0
        ret
...
rolw_bi:
        rolw    a0,a0,a1
        ret
...
```

