### PR TITLE
Fix (not)_single_bit_set predicate

### DIFF
--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -212,19 +212,9 @@
 
 ;; Predicates for the B extension.
 (define_predicate "single_bit_mask_operand"
-  (match_code "const_int")
-{
-  int val = pow2p_hwi (INTVAL (op));
-  if (val != -1)
-    return true;
-  return false;
-})
+  (and (match_code "const_int")
+       (match_test "pow2p_hwi (INTVAL (op))")))
 
 (define_predicate "not_single_bit_mask_operand"
-  (match_code "const_int")
-{
-  int val = pow2p_hwi (~INTVAL (op));
-  if (val != -1)
-    return true;
-  return false;
-})
+  (and (match_code "const_int")
+       (match_test "pow2p_hwi (~INTVAL (op))")))


### PR DESCRIPTION
Hi all,

This fixes regression test `990326-1.c` (probably with more others).

The predicates that are used for the `sbseti, sbclri, sbinvi, sbexti` is not correct:

```
;; Predicates for the B extension.
(define_predicate "single_bit_mask_operand"
  (match_code "const_int")
{
  int val = pow2p_hwi (INTVAL (op));
  if (val != -1)
    return true;
  return false;
})

(define_predicate "not_single_bit_mask_operand"
  (match_code "const_int")
{
  int val = pow2p_hwi (~INTVAL (op));
  if (val != -1)
    return true;
  return false;
})
```

`pow2p_hwi` is already a predicate that returns 1 iff the value is a power of two, and will never return -1.

Replace with a direct call to `pow2p_hwi`.
