### PR TITLE
Enable the constraints checking for assembler by default if possible.

### DIFF
--- a/gcc/config.in
+++ b/gcc/config.in
@@ -607,6 +607,12 @@
 #endif
 
 
+/* Define if your assembler supports .option checkconstraints. */
+#ifndef USED_FOR_TARGET
+#undef HAVE_AS_RISCV_CHECK_CONSTRAINTS
+#endif
+
+
 /* Define if your assembler supports relocs needed by -fpic. */
 #ifndef USED_FOR_TARGET
 #undef HAVE_AS_SMALL_PIC_RELOCS

--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -4399,6 +4399,9 @@ riscv_file_start (void)
   if (! riscv_mrelax)
     fprintf (asm_out_file, "\t.option norelax\n");
 
+  if (riscv_mcheck_constraints)
+    fprintf (asm_out_file, "\t.option checkconstraints\n");
+
   if (riscv_emit_attribute_p)
     riscv_emit_attribute ();
 }
@@ -4582,6 +4585,21 @@ riscv_option_override (void)
   if (riscv_emit_attribute_p)
     error ("%<-mriscv-attribute%> RISC-V ELF attribute requires GNU as 2.32"
 	   " [%<-mriscv-attribute%>]");
+#endif
+
+  /* If user don't set the `m[no-]check-constraints` option and assembler
+     support the constraints checking, then GCC should enable it by default.
+     If user set the `mcheck-constraints` options but the checking isn't
+     supported in assembler, then we should report error here.  */
+  if (riscv_mcheck_constraints < 0)
+#ifdef HAVE_AS_RISCV_CHECK_CONSTRAINTS
+    riscv_mcheck_constraints = 1;
+#else
+    riscv_mcheck_constraints = 0;
+
+  if (riscv_mcheck_constraints)
+    error ("%<-mcheck-constraints%> RISC-V constraints checking is unsupported"
+	   " in GNU as [%<-mcheck-constraints%>]");
 #endif
 }
 

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -147,3 +147,7 @@ Enum(riscv_align_data) String(xlen) Value(riscv_align_data_type_xlen)
 
 EnumValue
 Enum(riscv_align_data) String(natural) Value(riscv_align_data_type_natural)
+
+mcheck-constraints
+Target Report Var(riscv_mcheck_constraints) Init(-1)
+Enable the constraints checking for assembler.

--- a/gcc/configure
+++ b/gcc/configure
@@ -27635,6 +27635,41 @@ $as_echo "#define HAVE_AS_RISCV_ATTRIBUTE 1" >>confdefs.h
 
 fi
 
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking assembler for .option checkconstraints support" >&5
+$as_echo_n "checking assembler for .option checkconstraints support... " >&6; }
+if ${gcc_cv_as_riscv_check_constraints+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  gcc_cv_as_riscv_check_constraints=no
+    if test $in_tree_gas = yes; then
+    if test $gcc_cv_gas_vers -ge `expr \( \( 2 \* 1000 \) + 33 \) \* 1000 + 1`
+  then gcc_cv_as_riscv_check_constraints=yes
+fi
+  elif test x$gcc_cv_as != x; then
+    $as_echo '.option checkconstraints' > conftest.s
+    if { ac_try='$gcc_cv_as $gcc_cv_as_flags --fatal-warnings -o conftest.o conftest.s >&5'
+  { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_try\""; } >&5
+  (eval $ac_try) 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; }
+    then
+	gcc_cv_as_riscv_check_constraints=yes
+    else
+      echo "configure: failed program was" >&5
+      cat conftest.s >&5
+    fi
+    rm -f conftest.o conftest.s
+  fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $gcc_cv_as_riscv_check_constraints" >&5
+$as_echo "$gcc_cv_as_riscv_check_constraints" >&6; }
+if test $gcc_cv_as_riscv_check_constraints = yes; then
+
+$as_echo "#define HAVE_AS_RISCV_CHECK_CONSTRAINTS 1" >>confdefs.h
+
+fi
+
     ;;
     s390*-*-*)
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking assembler for .gnu_attribute support" >&5

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -4883,6 +4883,11 @@ pointers into PC-relative form.])
       [.attribute stack_align,4],,
       [AC_DEFINE(HAVE_AS_RISCV_ATTRIBUTE, 1,
 	  [Define if your assembler supports .attribute.])])
+    gcc_GAS_CHECK_FEATURE([.option checkconstraints support],
+      gcc_cv_as_riscv_check_constraints, [2,33,1],[--fatal-warnings],
+      [.option checkconstraints],,
+      [AC_DEFINE(HAVE_AS_RISCV_CHECK_CONSTRAINTS, 1,
+	  [Define if your assembler supports .option checkconstraints.])])
     ;;
     s390*-*-*)
     gcc_GAS_CHECK_FEATURE([.gnu_attribute support],

--- a/gcc/testsuite/gcc.target/riscv/constraints-1.c
+++ b/gcc/testsuite/gcc.target/riscv/constraints-1.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-O -mcheck-constraints" } */
+int foo()
+{
+}
+/* { dg-final { scan-assembler ".option checkconstraints" } } */

--- a/gcc/testsuite/gcc.target/riscv/constraints-2.c
+++ b/gcc/testsuite/gcc.target/riscv/constraints-2.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-O -mno-check-constraints" } */
+int foo()
+{
+}
+/* { dg-final { scan-not-assembler ".option checkconstraints" } } */


### PR DESCRIPTION
I get the request recently that the assembler's constraints checking break hardware exception test cases.  Therefore I have disabled the checking in assembler by default, and people don't get the constraints error when writing assembly code.  But we should enable the checking for the code which the compiler emits.

Beside, GCC also checks whether the assembler supports the options used to enable and disable the constraints checking.  The basic logic is shown as follows,

| | GAS support constraints options | GAS doesn't support constraints options
--- | --- | ---
GCC default | Output `.option checkconstraints` | Don't output the `.option checkconstraints`
GCC `-mcheck-constraints` | Output `.option checkconstraints` | Report error message that GAS doesn't support `.option checkconstraints`
GCC `-mno-check-constraints` | Don't output the`.option checkconstraints`| Don't output the`.option checkconstraints`

One more thing is that, the `gcc_GAS_CHECK_FEATURE` doesn't seem to work for checking the `.option xxx`.  I think the reason may be that GAS report warning message rather than error when the `.option xxx` isn't supported.  However, I have added both GAS options and .option directives for the
constraints checking, so I check them both in the `gcc_GAS_CHECK_FEATURE`.

	gcc/
	* config.in: Regenerated.
	* configure: Likewise.
	* configure.ac: Check whether GAS support constraints options.
	* config/riscv/riscv.c (riscv_option_override): If user don't set the
	`m[no-]check-constraints` option and GAS support the constraints
	checking, then GCC should enable it by default. If user set the
	`mcheck-constraints` options but the checking isn't supported in GAS,
	then we should report error message.
	(riscv_file_start): Emit `.option checkconstraints` if needed.
	* config/riscv/riscv.opt (mcheck-constraints): New option.

	gcc/testsuite/
	* gcc.target/riscv/constraints-1.c: New.
	* gcc.target/riscv/constraints-2.c: Likewise.