### PR TITLE
Refine use of sbseti for loading constants.

### DIFF
--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -469,9 +469,16 @@ enum reg_class
   (((VALUE & 0xffffffff) == VALUE) && (VALUE & 0x80000000)		\
    && SMALL_OPERAND (VALUE | (0xffffffffUL << 32)))
 
-/* If this is a single bit mask, then we can load it with sbseti.  */
+/* If this is a single bit mask, then we can load it with sbseti.  But this
+   is not useful for any of the low 31 bits because we can use addi or lui
+   to load them.  It is wrong for loading SImode 0x80000000 on rv64 because it
+   needs to be sign-extended.  So we restrict this to the upper 32-bits
+   only.  */
+/* ??? It is OK for DImode 0x80000000 on rv64, but we don't know the target
+   mode in riscv_build_integer_1 so can't handle this case separate from the
+   bad SImode case.  */
 #define SINGLE_BIT_MASK_OPERAND(VALUE) \
-  (pow2p_hwi (VALUE))
+  (pow2p_hwi (VALUE) && (ctz_hwi (VALUE) >= 32))
 
 /* Stack layout; function entry, exit and calling.  */
 


### PR DESCRIPTION
This is undesirable for bits 0 to 31 which should be loaded with addi or lui.
It fails for bit 32 which must be signed extended when it is a 32-bit value.
This case leads to an internal compiler error.  It can be used for a 64-bit
value with bit 32 set, but this can't be easily implemented.  So only allow it
for bits in the upper 32-bits of a 64-bit value.
