### PR TITLE
Add shNadd and shNaddu.w support.

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -336,6 +336,29 @@
 
 ;;; ??? fs[lr]
 
+(define_insn "*shNadd"
+  [(set (match_operand:X 0 "register_operand" "=r")
+	(plus:X (ashift:X (match_operand:X 1 "register_operand" "r")
+			  (match_operand:QI 2 "immediate_operand" "I"))
+		(match_operand:X 3 "register_operand" "r")))]
+  "TARGET_BITMANIP
+   && (INTVAL (operands[2]) >= 1) && (INTVAL (operands[2]) <= 3)"
+  "sh%2add\t%0,%1,%3"
+  [(set_attr "type" "bitmanip")])
+
+(define_insn "*shNadduw"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+	(plus:DI
+	 (and:DI (ashift:DI (match_operand:DI 1 "register_operand" "r")
+			    (match_operand:QI 2 "immediate_operand" "I"))
+		 (match_operand 3 "immediate_operand" ""))
+	 (match_operand:DI 4 "register_operand" "r")))]
+  "TARGET_64BIT && TARGET_BITMANIP
+   && (INTVAL (operands[2]) >= 1) && (INTVAL (operands[2]) <= 3)
+   && (INTVAL (operands[3]) >> INTVAL (operands[2])) == 0xffffffff"
+  "sh%2addu.w\t%0,%1,%4"
+  [(set_attr "type" "bitmanip")])
+
 (define_insn "*addwu"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(zero_extend:DI (plus:SI (match_operand:SI 1 "register_operand" "r")


### PR DESCRIPTION
No execution testing, only compilation testing, but works for the examples in the bitmanip extension manual.
