### PR TITLE
Fix compilation error for riscv_remove_unneeded_save_restore_calls

### DIFF
--- a/gcc/testsuite/gcc.target/riscv/save-restore-10.c
+++ b/gcc/testsuite/gcc.target/riscv/save-restore-10.c
@@ -1,0 +1,20 @@
+/* { dg-options "-Os -msave-restore" } */
+
+/* With -msave-restore, gcc should keep correct sp offset for assignment when
+   removing redundant save-restore calls */
+
+extern int
+foo (int);
+
+int
+#if defined(__riscv_32e)
+bar (int a, int b, int c, int d, int e, int f, int u)
+#else
+bar (int a, int b, int c, int d, int e, int f, int g, int h, int u)
+#endif
+{
+  int *p = &u;
+  return foo (p[a]);
+}
+
+/* { dg-final { scan-assembler "addi\[ \t\]*a\[0-7\],sp,0" } } */

--- a/gcc/testsuite/gcc.target/riscv/save-restore-9.c
+++ b/gcc/testsuite/gcc.target/riscv/save-restore-9.c
@@ -1,0 +1,19 @@
+/* { dg-options "-Os -msave-restore" } */
+
+/* With -msave-restore, gcc should keep correct sp offset of load when
+   removing redundant save-restore calls */
+
+extern int
+foo (int);
+
+int
+#if defined(__riscv_32e)
+bar (int a, int b, int c, int d, int e, int f, int u)
+#else
+bar (int a, int b, int c, int d, int e, int f, int g, int h, int u)
+#endif
+{
+  return foo (u);
+}
+
+/* { dg-final { scan-assembler "lw\[ \t\]*a0,0\\(sp\\)" } } */


### PR DESCRIPTION
Hi all,

This patch updates sp when removing save-restore. 
Gcc has compilation error when compiled the c file with option -msave-restore.

$ cat sample.c
int foo(int);
int bar(int a, int b, int c, int d, int e, int f, int g, int h, int u) {
  return foo(u);
}

$ riscv32-unknown-elf-gcc -march=rv32ima -mabi=ilp32 -S -Os -msave-restore sample.c
$ cat sample.s
bar:
    lw  a0,16(sp)
    tail    foo

`lw  a0,16(sp)` using wrong offset, the offset should be zero.