### PR TITLE
Fix rotate modes, must be QI same as shifts.

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -247,7 +247,7 @@
 (define_insn "rotrsi3"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(rotatert:SI (match_operand:SI 1 "register_operand" "r")
-		     (match_operand:SI 2 "arith_operand" "rI")))]
+		     (match_operand:QI 2 "arith_operand" "rI")))]
   "TARGET_BITMANIP"
   { return TARGET_64BIT ? "ror%i2w\t%0,%1,%2" : "ror%i2\t%0,%1,%2"; }
   [(set_attr "type" "bitmanip")])
@@ -255,7 +255,7 @@
 (define_insn "rotrdi3"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(rotatert:DI (match_operand:DI 1 "register_operand" "r")
-		     (match_operand:DI 2 "arith_operand" "rI")))]
+		     (match_operand:QI 2 "arith_operand" "rI")))]
   "TARGET_64BIT && TARGET_BITMANIP"
   "ror%i2\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
@@ -273,7 +273,7 @@
 (define_insn "rotlsi3"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(rotate:SI (match_operand:SI 1 "register_operand" "r")
-		   (match_operand:SI 2 "register_operand" "r")))]
+		   (match_operand:QI 2 "register_operand" "r")))]
   "TARGET_BITMANIP"
   { return TARGET_64BIT ? "rolw\t%0,%1,%2" : "rol\t%0,%1,%2"; }
   [(set_attr "type" "bitmanip")])
@@ -281,7 +281,7 @@
 (define_insn "rotldi3"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(rotate:DI (match_operand:DI 1 "register_operand" "r")
-		   (match_operand:DI 2 "register_operand" "r")))]
+		   (match_operand:QI 2 "register_operand" "r")))]
   "TARGET_64BIT && TARGET_BITMANIP"
   "rol\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
@@ -289,7 +289,7 @@
 (define_insn "rotlsi3_sext"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(sign_extend:DI (rotate:SI (match_operand:SI 1 "register_operand" "r")
-				   (match_operand:SI 2 "register_operand" "r"))))]
+				   (match_operand:QI 2 "register_operand" "r"))))]
   "TARGET_64BIT && TARGET_BITMANIP"
   "rolw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])


### PR DESCRIPTION
/* Expect li -2 and rol.  */
/* Or sbsetw and not.  */
long
li_rol_or_sbset_not (long i)
{
  return ~(1L << i);
}

Without rotate mode fix, we get
li_rol_or_sbset_not:
        li      a5,1
        sll     a0,a5,a0
        not     a0,a0
        ret
with rotate mode fix we get
li_rol_or_sbset_not:
        li      a5,-2
        rol     a0,a5,a0
        ret

Also sbset/not should be option if no rol, but there is a pttern missing.  That is my next patch.
