### PR TITLE
Add sbset with constant 1 input.

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -133,6 +133,14 @@
   "sbset\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
+(define_insn "*sbset<mode>_1"
+  [(set (match_operand:X 0 "register_operand" "=r")
+	(ashift:X (const_int 1)
+		  (match_operand:QI 1 "register_operand" "r")))]
+  "TARGET_BITMANIP"
+  "sbset\t%0,x0,%1"
+  [(set_attr "type" "bitmanip")])
+
 (define_insn "*sbseti<mode>"
   [(set (match_operand:X 0 "register_operand" "=r")
 	(ior:X (match_operand:X 1 "register_operand" "r")


### PR DESCRIPTION
Testcase is same as the rotate mode fix, except now for
long
li_rol_or_sbset_not (long i)
{
  return ~(1L << i);
}
we get if Zbs enabled
li_rol_or_sbset_not:
        sbset   a0,x0,a0
        not     a0,a0
        ret
