### PR TITLE
Use li and rori to load constants.

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -455,6 +455,47 @@ riscv_build_integer_1 (struct riscv_integer_op codes[RISCV_MAX_INTEGER_OPS],
 	}
     }
 
+  if (cost > 2 && TARGET_64BIT && TARGET_BITMANIP)
+    {
+      int leading_ones = clz_hwi (~value);
+      int trailing_ones = ctz_hwi (~value);
+
+      /* If all bits are one except a few that are zero, and the zero bits
+	 are within a range of 11 bits, and at least one of the upper 32-bits
+	 is a zero, then we can generate a constant by loading a small
+	 negative constant and rotating.  */
+      if (leading_ones < 32
+	  && ((64 - leading_ones - trailing_ones) < 12))
+	{
+	  codes[0].code = UNKNOWN;
+	  /* The sign-bit might be zero, so just rotate to be safe.  */
+	  codes[0].value = (((unsigned HOST_WIDE_INT) value >> trailing_ones)
+			    | (value << (64 - trailing_ones)));
+	  codes[1].code = ROTATERT;
+	  codes[1].value = 64 - trailing_ones;
+	  cost = 2;
+	}
+      /* Handle the case where the 11 bit range of zero bits wraps around.  */
+      else
+	{
+	  int upper_trailing_ones = ctz_hwi (~value >> 32);
+	  int lower_leading_ones = clz_hwi (~value << 32);
+
+	  if (upper_trailing_ones < 32 && lower_leading_ones < 32
+	      && ((64 - upper_trailing_ones - lower_leading_ones) < 12))
+	    {
+	      codes[0].code = UNKNOWN;
+	      /* The sign-bit might be zero, so just rotate to be safe.  */
+	      codes[0].value = ((value << (32 - upper_trailing_ones))
+				| ((unsigned HOST_WIDE_INT) value
+				   >> (32 + upper_trailing_ones)));
+	      codes[1].code = ROTATERT;
+	      codes[1].value = 32 - upper_trailing_ones;
+	      cost = 2;
+	    }
+	}
+    }
+
   gcc_assert (cost <= RISCV_MAX_INTEGER_OPS);
   return cost;
 }


### PR DESCRIPTION
I doubt that this will help many applications, the constants are a bit too obscure.  But we may as well try to get these cases right just in case.

This only handles the li negative followed by rori case.  There are a few more cases we could handle.  li positive followed by rori is useful for the case where the ones wrap around.  For instance 0xf00000000000000f could be loaded with li 255; rori 4.  We can also load some constants using lui followed by rori.  There may also be other cases I haven't thought of yet.

There are other ways to implement this.  I haven't given this much thought yet.  For instance, we could call ctz, then rotate by that amount, and then check for a SMALL_INT constant.  That might be easier to understand than the current code.  That doesn't work for the wraparound case, but we could rotate by 32, call ctz, rotate again, and then check for a SMALL_INT.
