### PR TITLE
Fix slliuw support, disable non-B splitter.

### DIFF
--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1839,7 +1839,7 @@
 			   (match_operand:QI 2 "immediate_operand" "I"))
 		(match_operand 3 "immediate_operand" "")))
    (clobber (match_scratch:DI 4 "=&r"))]
-  "TARGET_64BIT
+  "TARGET_64BIT && !TARGET_BITMANIP
    && ((INTVAL (operands[3]) >> INTVAL (operands[2])) == 0xffffffff)"
   "#"
   "&& reload_completed"


### PR DESCRIPTION
Fix issue documented in riscv-bitmanip issue 65.  The testcase is:

long
slliuw (long i)
{
  return (long)(unsigned int)i << 10;
}

which should generate a slliuw instruction when the B extension is enabled.