### PR TITLE
Store large value in register, when value is out of range in a ADD instruction

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -4511,8 +4511,7 @@ riscv_expand_epilogue (int style)
       poly_int64 adjust = -frame->hard_frame_pointer_offset;
       rtx adjust_rtx = NULL_RTX;
 
-      if (!adjust.is_constant ()
-	  || (adjust.is_constant () && !SMALL_OPERAND (adjust.is_constant())))
+      if (!adjust.is_constant ())
 	{
 	  rtx tmp1 = RISCV_PROLOGUE_TEMP (Pmode);
 	  rtx tmp2 = RISCV_PROLOGUE_TEMP2 (Pmode);
@@ -4520,7 +4519,16 @@ riscv_expand_epilogue (int style)
 	  adjust_rtx = tmp1;
 	}
       else
-	adjust_rtx = GEN_INT (adjust.to_constant ());
+	{
+	  if (!SMALL_OPERAND (adjust.to_constant ()))
+	    {
+	      riscv_emit_move (RISCV_PROLOGUE_TEMP (Pmode),
+			       GEN_INT (adjust.to_constant ()));
+	      adjust_rtx = RISCV_PROLOGUE_TEMP (Pmode);
+	    }
+	  else
+	    adjust_rtx = GEN_INT (adjust.to_constant ());
+	}
 
       insn = emit_insn (
 	       gen_add3_insn (stack_pointer_rtx, hard_frame_pointer_rtx,

--- a/gcc/testsuite/gcc.target/riscv/check-stack.c
+++ b/gcc/testsuite/gcc.target/riscv/check-stack.c
@@ -1,0 +1,12 @@
+/* { dg-do run } */
+/* { dg-options "-O0" } */
+
+/* Allocate a large stack size to check stack point can be adjusted.  */
+int main(void)
+{
+  int *p;
+  int i[2000];
+  p = __builtin_alloca(2);
+
+  return 0;
+}


### PR DESCRIPTION
If offset is out of range in a  ADDI instruction. So Sp will not insert a instruction to adjust Sp value.

The testcase is:

int main(void)
{
  int *p;
  int i[2000];
  p = __builtin_alloca(2);

  return 0;
}
