### PR TITLE
Merge gcc 10.2.0 to gcc 10.2.0-rvb

### DIFF
--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -524,6 +524,14 @@ riscv_subset_list::parse_multiletter_ext (const char *p,
 
       *q = '\0';
 
+      if (strlen (subset) == 1)
+	{
+	  error_at (m_loc, "%<-march=%s%>: name of %s must be more than 1 letter",
+		    m_arch, ext_type_str);
+	  free (subset);
+	  return NULL;
+	}
+
       add (subset, major_version, minor_version, explicit_version_p);
       free (subset);
       p += end_of_version - subset;

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -2450,11 +2450,13 @@ riscv*-*-elf* | riscv*-*-rtems*)
 	  tmake_file="${tmake_file} riscv/t-rtems"
 	  ;;
 	*)
-	  case "x${enable_multilib}" in
-	  xno) ;;
-	  xyes) tmake_file="${tmake_file} riscv/t-elf-multilib" ;;
-	  *) echo "Unknown value for enable_multilib"; exit 1
-	  esac
+	  if test "x${with_multilib_generator}" == xdefault; then
+		  case "x${enable_multilib}" in
+		  xno) ;;
+		  xyes) tmake_file="${tmake_file} riscv/t-elf-multilib" ;;
+		  *) echo "Unknown value for enable_multilib"; exit 1
+		  esac
+	  fi
 	esac
 	tmake_file="${tmake_file} riscv/t-riscv"
 	gnu_ld=yes
@@ -4581,6 +4583,30 @@ case "${target}" in
 			exit 1
 			;;
 		esac
+		# Handle --with-multilib-generator.
+		if test "x${with_multilib_generator}" != xdefault; then
+			if test "x${with_multilib_list}" != xdefault; then
+				echo "--with-multilib-list= can't used with --with-multilib-generator= at same time" 1>&2
+				exit 1
+			fi
+			case "${target}" in
+			riscv*-*-elf*)
+				if ${srcdir}/config/riscv/multilib-generator \
+					`echo ${with_multilib_generator} | sed 's/;/ /g'`\
+					> t-multilib-config;
+				then
+					tmake_file="${tmake_file} riscv/t-withmultilib-generator"
+				else
+					echo "invalid option for --with-multilib-generator" 1>&2
+					exit 1
+				fi
+				;;
+			*)
+				echo "--with-multilib-generator= is not supported for ${target}, only supported for riscv*-*-elf*" 1>&2
+				exit 1
+				;;
+			esac
+		fi
 
 		# Handle --with-multilib-list.
 		if test "x${with_multilib_list}" != xdefault; then

--- a/gcc/config/riscv/multilib-generator
+++ b/gcc/config/riscv/multilib-generator
@@ -38,8 +38,14 @@ reuse = []
 
 canonical_order = "mafdgqlcbjtpvn"
 
+#
+# IMPLIED_EXT(ext) -> implied extension list.
+#
+IMPLIED_EXT = {
+  "d" : ["f"],
+}
+
 def arch_canonicalize(arch):
-  # TODO: Support implied extensions, e.g. D implied F in latest spec.
   # TODO: Support extension version.
   new_arch = ""
   if arch[:5] in ['rv32e', 'rv32i', 'rv32g', 'rv64i', 'rv64g']:
@@ -57,14 +63,24 @@ def arch_canonicalize(arch):
   if long_ext_prefixes_idx:
     first_long_ext_idx = min(long_ext_prefixes_idx)
     long_exts = arch[first_long_ext_idx:].split("_")
-    std_exts = arch[5:first_long_ext_idx]
+    std_exts = list(arch[5:first_long_ext_idx])
   else:
     long_exts = []
-    std_exts = arch[5:]
+    std_exts = list(arch[5:])
+
+  #
+  # Handle implied extensions.
+  #
+  for ext in std_exts + long_exts:
+    if ext in IMPLIED_EXT:
+      implied_exts = IMPLIED_EXT[ext]
+      for implied_ext in implied_exts:
+        if implied_ext not in std_exts + long_exts:
+          long_exts.append(implied_ext)
 
   # Single letter extension might appear in the long_exts list,
   # becasue we just append extensions list to the arch string.
-  std_exts += "".join(filter(lambda x:len(x) == 1, long_exts))
+  std_exts += list(filter(lambda x:len(x) == 1, long_exts))
 
   # Multi-letter extension must be in lexicographic order.
   long_exts = sorted(filter(lambda x:len(x) != 1, long_exts))

--- a/gcc/config/riscv/multilib-generator
+++ b/gcc/config/riscv/multilib-generator
@@ -194,7 +194,14 @@ def expand_combination(ext):
   return ext
 
 for cfg in sys.argv[1:]:
-  (arch, abi, extra, ext) = cfg.split('-')
+  try:
+    (arch, abi, extra, ext) = cfg.split('-')
+  except:
+    print ("Invalid configure string %s, <arch>-<abi>-<extra>-<extensions>\n"
+           "<extra> and <extensions> can be empty, "
+           "e.g. rv32imafd-ilp32--" % cfg)
+    sys.exit(1)
+
   arch = arch_canonicalize (arch)
   arches[arch] = 1
   abis[abi] = 1

--- a/gcc/config/riscv/multilib-generator
+++ b/gcc/config/riscv/multilib-generator
@@ -22,14 +22,26 @@
 
 # Each argument to this script is of the form
 #  <primary arch>-<abi>-<additional arches>-<extensions>
-# For example,
+# Example 1:
 #  rv32imafd-ilp32d-rv32g-c,v
 # means that, in addition to rv32imafd, these configurations can also use the
 # rv32imafd-ilp32d libraries: rv32imafdc, rv32imafdv, rv32g, rv32gc, rv32gv
+#
+# Example 2:
+#  rv32imafd-ilp32d--c*b
+# means that, in addition to rv32imafd, these configurations can also use the
+# rv32imafd-ilp32d libraries: rv32imafdc-ilp32d, rv32imafdb-ilp32d,
+#                             rv32imafdcb-ilp32d
 
 from __future__ import print_function
 import sys
 import collections
+import itertools
+from functools import reduce
+
+#
+# TODO: Add test for this script.
+#
 
 arches = collections.OrderedDict()
 abis = collections.OrderedDict()
@@ -37,6 +49,7 @@ required = []
 reuse = []
 
 canonical_order = "mafdgqlcbjtpvn"
+LONG_EXT_PREFIXES = ['z', 's', 'h', 'x']
 
 #
 # IMPLIED_EXT(ext) -> implied extension list.
@@ -49,14 +62,13 @@ def arch_canonicalize(arch):
   # TODO: Support extension version.
   new_arch = ""
   if arch[:5] in ['rv32e', 'rv32i', 'rv32g', 'rv64i', 'rv64g']:
-    # TODO: We should expand g to imadzifencei once we support newer spec.
+    # TODO: We should expand g to imad_zifencei once we support newer spec.
     new_arch = arch[:5].replace("g", "imafd")
   else:
     raise Exception("Unexpected arch: `%s`" % arch[:5])
 
   # Find any Z, S, H or X
-  long_ext_prefixes = ['z', 's', 'h', 'x']
-  long_ext_prefixes_idx = map(lambda x: arch.find(x), long_ext_prefixes)
+  long_ext_prefixes_idx = map(lambda x: arch.find(x), LONG_EXT_PREFIXES)
 
   # Filter out any non-existent index.
   long_ext_prefixes_idx = list(filter(lambda x: x != -1, long_ext_prefixes_idx))
@@ -83,7 +95,7 @@ def arch_canonicalize(arch):
   std_exts += list(filter(lambda x:len(x) == 1, long_exts))
 
   # Multi-letter extension must be in lexicographic order.
-  long_exts = sorted(filter(lambda x:len(x) != 1, long_exts))
+  long_exts = list(sorted(filter(lambda x:len(x) != 1, long_exts)))
 
   # Put extensions in canonical order.
   for ext in canonical_order:
@@ -102,15 +114,98 @@ def arch_canonicalize(arch):
     new_arch += "_" + "_".join(long_exts)
   return new_arch
 
+#
+# add underline for each multi-char extensions.
+# e.g. ["a", "zfh"] -> ["a", "_zfh"]
+#
+def add_underline_prefix(ext):
+  for long_ext_prefix in LONG_EXT_PREFIXES:
+    if ext.startswith(long_ext_prefix):
+      return "_" + ext
+
+  return ext
+
+#
+# Handle expansion operation.
+#
+# e.g. "a*b" -> [("a",), ("b",), ("a", "b")]
+#      "a"   -> [("a",)]
+#
+def _expand_combination(ext):
+  exts = list(ext.split("*"))
+
+  # No need to expand if there is no `*`.
+  if len(exts) == 1:
+    return [(exts[0],)]
+
+  # Add underline to every extension.
+  # e.g.
+  #  _b * zvamo => _b * _zvamo
+  exts = list(map(lambda x: '_' + x, exts))
+
+  # Generate combination!
+  ext_combs = []
+  for comb_len in range(1, len(exts)+1):
+    for ext_comb in itertools.combinations(exts, comb_len):
+      ext_combs.append(ext_comb)
+
+  return ext_combs
+
+#
+# Input a list and drop duplicated entry.
+# e.g.
+#   ["a", "b", "ab", "a"] -> ["a", "b", "ab"]
+#
+def unique(x):
+  #
+  # Drop duplicated entry.
+  # Convert list to set and then convert back to list.
+  #
+  # Add sorted to prevent non-deterministic results in different env.
+  #
+  return list(sorted(list(set(x))))
+
+#
+# Expand EXT string if there is any expansion operator (*).
+# e.g.
+#   "a*b,c" -> ["a", "b", "ab", "c"]
+#
+def expand_combination(ext):
+  ext = list(filter(None, ext.split(',')))
+
+  # Expand combination for EXT, got lots of list.
+  # e.g.
+  #   a * b => [[("a",), ("b",)], [("a", "b")]]
+  ext_combs = list(map(_expand_combination, ext))
+
+  # Then fold to single list.
+  # e.g.
+  #   [[("a",), ("b",)], [("a", "b")]] => [("a",), ("b",), ("a", "b")]
+  ext = list(reduce(lambda x, y: x + y, ext_combs, []))
+
+  # Fold the tuple to string.
+  # e.g.
+  #   [("a",), ("b",), ("a", "b")] => ["a", "b", "ab"]
+  ext = map(lambda e : reduce(lambda x, y: x + y, e), ext)
+
+  # Drop duplicated entry.
+  ext = unique(ext)
+
+  return ext
+
 for cfg in sys.argv[1:]:
   (arch, abi, extra, ext) = cfg.split('-')
   arch = arch_canonicalize (arch)
   arches[arch] = 1
   abis[abi] = 1
   extra = list(filter(None, extra.split(',')))
-  ext = list(filter(None, ext.split(',')))
-  alts = sum([[x] + [x + "_" + y for y in ext] for x in [arch] + extra], [])
+  ext_combs = expand_combination(ext)
+  alts = sum([[x] + [x + y for y in ext_combs] for x in [arch] + extra], [])
   alts = list(map(arch_canonicalize, alts))
+
+  # Drop duplicated entry.
+  alts = unique(alts)
+
   for alt in alts[1:]:
     arches[alt] = 1
     reuse.append('march.%s/mabi.%s=march.%s/mabi.%s' % (arch, abi, alt, abi))

--- a/gcc/config/riscv/riscv-c.c
+++ b/gcc/config/riscv/riscv-c.c
@@ -90,12 +90,15 @@ riscv_cpu_cpp_builtins (cpp_reader *pfile)
       builtin_define ("__riscv_cmodel_medlow");
       break;
 
+    case CM_PIC:
+      /* __riscv_cmodel_pic is deprecated, and will removed in next GCC release.
+	 see https://github.com/riscv/riscv-c-api-doc/pull/11  */
+      builtin_define ("__riscv_cmodel_pic");
+      /* FALLTHROUGH. */
+
     case CM_MEDANY:
       builtin_define ("__riscv_cmodel_medany");
       break;
 
-    case CM_PIC:
-      builtin_define ("__riscv_cmodel_pic");
-      break;
     }
 }

--- a/gcc/config/riscv/riscv-cores.def
+++ b/gcc/config/riscv/riscv-cores.def
@@ -1,0 +1,49 @@
+/* List of supported core and tune info for RISC-V.
+   Copyright (C) 2020 Free Software Foundation, Inc.
+
+   This file is part of GCC.
+
+   GCC is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
+
+   GCC is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GCC; see the file COPYING3.  If not see
+   <http://www.gnu.org/licenses/>.  */
+
+/* This is a list of cores that implement RISC-V.
+
+   Before using #include to read this file, define a macro:
+
+      RISCV_CORE(CORE_NAME, ARCH, MICRO_ARCH, TUNE_INFO)
+
+   The CORE_NAME is the name of the core, represented as a string.
+   The ARCH is the default arch of the core, represented as a string,
+   can be NULL if no default arch.
+   The MICRO_ARCH is the name of the core for which scheduling decisions
+   will be made, represented as an identifier.
+   The TUNE_INFO is the detail cost model for this core, represented as an
+   identifier, reference to riscv-tunes.def.  */
+
+RISCV_CORE("sifive-e20",      "rv32imc",    "rocket")
+RISCV_CORE("sifive-e21",      "rv32imac",   "rocket")
+RISCV_CORE("sifive-e24",      "rv32imafc",  "rocket")
+RISCV_CORE("sifive-e31",      "rv32imac",   "sifive-3-series")
+RISCV_CORE("sifive-e34",      "rv32imafc",  "sifive-3-series")
+RISCV_CORE("sifive-e76",      "rv32imafc",  "sifive-7-series")
+
+RISCV_CORE("sifive-s21",      "rv64imac",   "rocket")
+RISCV_CORE("sifive-s51",      "rv64imac",   "sifive-5-series")
+RISCV_CORE("sifive-s54",      "rv64imafdc", "sifive-5-series")
+RISCV_CORE("sifive-s76",      "rv64imafdc", "sifive-7-series")
+
+RISCV_CORE("sifive-u54",      "rv64imafdc", "sifive-5-series")
+RISCV_CORE("sifive-u74",      "rv64imafdc", "sifive-7-series")
+
+#undef RISCV_CORE

--- a/gcc/config/riscv/riscv-protos.h
+++ b/gcc/config/riscv/riscv-protos.h
@@ -94,4 +94,18 @@ extern bool riscv_hard_regno_rename_ok (unsigned, unsigned);
 
 rtl_opt_pass * make_pass_shorten_memrefs (gcc::context *ctxt);
 
+/* Information about one CPU we know about.  */
+struct riscv_cpu_info {
+  /* This CPU's canonical name.  */
+  const char *name;
+
+  /* Default arch for this CPU, could be NULL if no default arch.  */
+  const char *arch;
+
+  /* Which automaton to use for tuning.  */
+  const char *tune;
+};
+
+extern const riscv_cpu_info *riscv_find_cpu (const char *);
+
 #endif /* ! GCC_RISCV_PROTOS_H */

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -41,17 +41,27 @@ along with GCC; see the file COPYING3.  If not see
 #endif
 
 extern const char *riscv_expand_arch (int argc, const char **argv);
+extern const char *riscv_expand_arch_from_cpu (int argc, const char **argv);
+extern const char *riscv_default_mtune (int argc, const char **argv);
 
 # define EXTRA_SPEC_FUNCTIONS						\
-  { "riscv_expand_arch", riscv_expand_arch },
+  { "riscv_expand_arch", riscv_expand_arch },				\
+  { "riscv_expand_arch_from_cpu", riscv_expand_arch_from_cpu },		\
+  { "riscv_default_mtune", riscv_default_mtune },
 
 /* Support for a compile-time default CPU, et cetera.  The rules are:
-   --with-arch is ignored if -march is specified.
+   --with-arch is ignored if -march or -mcpu is specified.
    --with-abi is ignored if -mabi is specified.
-   --with-tune is ignored if -mtune is specified.  */
+   --with-tune is ignored if -mtune or -mcpu is specified.
+
+   But using default -march/-mtune value if -mcpu don't have valid option.  */
 #define OPTION_DEFAULT_SPECS \
-  {"tune", "%{!mtune=*:-mtune=%(VALUE)}" }, \
-  {"arch", "%{!march=*:-march=%(VALUE)}" }, \
+  {"tune", "%{!mtune=*:"						\
+	   "  %{!mcpu=*:-mtune=%(VALUE)}"				\
+	   "  %{mcpu=*:-mtune=%:riscv_default_mtune(%* %(VALUE))}}" },	\
+  {"arch", "%{!march=*:"						\
+	   "  %{!mcpu=*:-march=%(VALUE)}"				\
+	   "  %{mcpu=*:%:riscv_expand_arch_from_cpu(%* %(VALUE))}}" },	\
   {"abi", "%{!mabi=*:-mabi=%(VALUE)}" }, \
 
 #ifdef IN_LIBGCC2
@@ -69,8 +79,9 @@ extern const char *riscv_expand_arch (int argc, const char **argv);
 %(subtarget_asm_spec)"
 
 #undef DRIVER_SELF_SPECS
-#define DRIVER_SELF_SPECS \
-"%{march=*:-march=%:riscv_expand_arch(%*)}"
+#define DRIVER_SELF_SPECS					\
+"%{march=*:%:riscv_expand_arch(%*)} "				\
+"%{!march=*:%{mcpu=*:%:riscv_expand_arch_from_cpu(%*)}} "
 
 #define TARGET_DEFAULT_CMODEL CM_MEDLOW
 

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -941,7 +941,7 @@ extern unsigned riscv_stack_boundary;
 
 /* This is the maximum value that can be represented in a compressed load/store
    offset (an unsigned 5-bit value scaled by 4).  */
-#define CSW_MAX_OFFSET ((4LL << C_S_BITS) - 1) & ~3
+#define CSW_MAX_OFFSET (((4LL << C_S_BITS) - 1) & ~3)
 
 /* Called from RISCV_REORG, this is defined in riscv-sr.c.  */
 

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -79,6 +79,10 @@ mtune=
 Target RejectNegative Joined Var(riscv_tune_string)
 -mtune=PROCESSOR	Optimize the output for PROCESSOR.
 
+mcpu=
+Target RejectNegative Joined Var(riscv_cpu_string)
+-mcpu=PROCESSOR	Use architecture of and optimize the output for PROCESSOR.
+
 msmall-data-limit=
 Target Joined Separate UInteger Var(g_switch_value) Init(8)
 -msmall-data-limit=N	Put global and static data smaller than <number> bytes into a special section (on some targets).

--- a/gcc/config/riscv/t-riscv
+++ b/gcc/config/riscv/t-riscv
@@ -24,3 +24,5 @@ riscv-shorten-memrefs.o: $(srcdir)/config/riscv/riscv-shorten-memrefs.c
 	$(POSTCOMPILE)
 
 PASSES_EXTRA += $(srcdir)/config/riscv/riscv-passes.def
+
+$(common_out_file): $(srcdir)/config/riscv/riscv-cores.def

--- a/gcc/config/riscv/t-withmultilib-generator
+++ b/gcc/config/riscv/t-withmultilib-generator
@@ -1,0 +1,2 @@
+# t-multilib-config will generated in build folder by configure script.
+include t-multilib-config

--- a/gcc/configure
+++ b/gcc/configure
@@ -969,6 +969,7 @@ with_documentation_root_url
 with_changes_root_url
 enable_languages
 with_multilib_list
+with_multilib_generator
 with_zstd
 with_zstd_include
 with_zstd_lib
@@ -1806,6 +1807,8 @@ Optional Packages:
   --with-changes-root-url=URL
                           Root for GCC changes URLs
   --with-multilib-list    select multilibs (AArch64, SH and x86-64 only)
+  --with-multilib-generator
+                          Multi-libs configuration string (RISC-V only)
   --with-zstd=PATH        specify prefix directory for installed zstd library.
                           Equivalent to --with-zstd-include=PATH/include plus
                           --with-zstd-lib=PATH/lib
@@ -8003,6 +8006,15 @@ if test "${with_multilib_list+set}" = set; then :
   withval=$with_multilib_list; :
 else
   with_multilib_list=default
+fi
+
+
+
+# Check whether --with-multilib-generator was given.
+if test "${with_multilib_generator+set}" = set; then :
+  withval=$with_multilib_generator; :
+else
+  with_multilib_generator=default
 fi
 
 
@@ -19020,7 +19032,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 19023 "configure"
+#line 19035 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -19126,7 +19138,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 19129 "configure"
+#line 19141 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H

--- a/gcc/configure
+++ b/gcc/configure
@@ -10024,9 +10024,14 @@ $as_echo_n "checking for zstd.h... " >&6; }
 if ${gcc_cv_header_zstd_h+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+  # We require version 1.3.0 or later.  This is the first version that has
+# ZSTD_getFrameContentSize.
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <zstd.h>
+#if ZSTD_VERSION_NUMBER < 10300
+#error "need zstd 1.3.0 or better"
+#endif
 int
 main ()
 {
@@ -19015,7 +19020,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 19018 "configure"
+#line 19023 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -19121,7 +19126,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<_LT_EOF
-#line 19124 "configure"
+#line 19129 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -1110,6 +1110,11 @@ AC_ARG_WITH(multilib-list,
 :,
 with_multilib_list=default)
 
+AC_ARG_WITH(multilib-generator,
+[AS_HELP_STRING([--with-multilib-generator], [Multi-libs configuration string (RISC-V only)])],
+:,
+with_multilib_generator=default)
+
 # -------------------------
 # Checks for other programs
 # -------------------------

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -1382,8 +1382,13 @@ LDFLAGS="$LDFLAGS $ZSTD_LDFLAGS"
 
 AC_MSG_CHECKING(for zstd.h)
 AC_CACHE_VAL(gcc_cv_header_zstd_h,
+# We require version 1.3.0 or later.  This is the first version that has
+# ZSTD_getFrameContentSize.
 [AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-[[#include <zstd.h>]])],
+[[#include <zstd.h>
+#if ZSTD_VERSION_NUMBER < 10300
+#error "need zstd 1.3.0 or better"
+#endif]])],
   [gcc_cv_header_zstd_h=yes],
   [gcc_cv_header_zstd_h=no])])
 AC_MSG_RESULT($gcc_cv_header_zstd_h)

--- a/gcc/doc/install.texi
+++ b/gcc/doc/install.texi
@@ -1250,6 +1250,37 @@ If @option{--with-multilib-list} is not given, then only 32-bit and
 64-bit run-time libraries will be enabled.
 @end table
 
+@item --with-multilib-generator=@var{config}
+Specify what multilibs to build.  @var{config} is a semicolon separated list of
+values, possibly consisting of a single value.  Currently only implemented
+for riscv*-*-elf*.  The accepted values and meanings are given below.
+
+
+Every config is constructed with four components: architecture string, ABI,
+reuse rule with architecture string and reuse rule with sub-extension.
+
+Example 1: Add multi-lib suppport for rv32i with ilp32.
+@smallexample
+rv32i-ilp32--
+@end smallexample
+
+Example 2: Add multi-lib suppport for rv32i with ilp32 and rv32imafd with ilp32.
+@smallexample
+rv32i-ilp32--;rv32imafd-ilp32--
+@end smallexample
+
+Example 3: Add multi-lib suppport for rv32i with ilp32; rv32im with ilp32 and
+rv32ic with ilp32 will reuse this multi-lib set.
+@smallexample
+rv32i-ilp32-rv32im-c
+@end smallexample
+
+Example 4: Add multi-lib suppport for rv64ima with lp64; rv64imaf with lp64,
+rv64imac with lp64 and rv64imafc with lp64 will reuse this multi-lib set.
+@smallexample
+rv64ima-lp64--f,c,fc
+@end smallexample
+
 @item --with-endian=@var{endians}
 Specify what endians to use.
 Currently only implemented for sh*-*-*.

--- a/gcc/doc/invoke.texi
+++ b/gcc/doc/invoke.texi
@@ -25314,14 +25314,30 @@ Generate code for given RISC-V ISA (e.g.@: @samp{rv64im}).  ISA strings must be
 lower-case.  Examples include @samp{rv64i}, @samp{rv32g}, @samp{rv32e}, and
 @samp{rv32imaf}.
 
+When @option{-march=} is not specified, use the setting from @option{-mcpu}.
+
+If both @option{-march} and @option{-mcpu=} are not specified, the default for
+this argument is system dependent, users who want a specific architecture
+extensions should specify one explicitly.
+
+@item -mcpu=@var{processor-string}
+@opindex mcpu
+Use architecture of and optimize the output for the given processor, specified
+by particular CPU name.
+Permissible values for this option are: @samp{sifive-e20}, @samp{sifive-e21},
+@samp{sifive-e24}, @samp{sifive-e31}, @samp{sifive-e34}, @samp{sifive-e76},
+@samp{sifive-s21}, @samp{sifive-s51}, @samp{sifive-s54}, @samp{sifive-s76},
+@samp{sifive-u54}, and @samp{sifive-u74}.
+
 @item -mtune=@var{processor-string}
 @opindex mtune
-Optimize the output for the given processor, specified by microarchitecture
-name.  Permissible values for this option are: @samp{rocket},
+Optimize the output for the given processor, specified by microarchitecture or
+particular CPU name.  Permissible values for this option are: @samp{rocket},
 @samp{sifive-3-series}, @samp{sifive-5-series}, @samp{sifive-7-series},
-and @samp{size}.
+@samp{size}, and all valid options for @option{-mcpu=}.
 
-When @option{-mtune=} is not specified, the default is @samp{rocket}.
+When @option{-mtune=} is not specified, use the setting from @option{-mcpu},
+the default is @samp{rocket} if both are not specified.
 
 The @samp{size} choice is not intended for use by end-users.  This is used
 when @option{-Os} is specified.  It overrides the instruction cost info

--- a/gcc/testsuite/gcc.target/riscv/arch-7.c
+++ b/gcc/testsuite/gcc.target/riscv/arch-7.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -march=rv32i -march=rv32im_s -mabi=ilp32" } */
+int foo()
+{
+}
+/* { dg-error ".'-march=rv32im_s': name of supervisor extension must be more than 1 letter" "" { target *-*-* } 0 } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-10.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-10.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O2 -march=rv32i -march=rv32im_s_sx_unexpectedstring -mabi=ilp32" } */
+/* { dg-options "-O2 -march=rv32i -march=rv32im_sx_unexpectedstring -mabi=ilp32" } */
 int foo()
 {
 }

--- a/gcc/testsuite/gcc.target/riscv/mcpu-1.c
+++ b/gcc/testsuite/gcc.target/riscv/mcpu-1.c
@@ -1,0 +1,18 @@
+/* { dg-do compile } */
+/* { dg-skip-if "-march given" { *-*-* } { "-march=*" } } */
+/* { dg-options "-mcpu=sifive-e20 -mabi=ilp32" } */
+/* sifive-e20 = rv32imc */
+
+#if !((__riscv_xlen == 32)		\
+      && !defined(__riscv_32e)		\
+      && defined(__riscv_mul)		\
+      && !defined(__riscv_atomic)	\
+      && !defined(__riscv_flen)		\
+      && defined(__riscv_compressed))
+#error "unexpected arch"
+#endif
+
+int main()
+{
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/riscv/mcpu-2.c
+++ b/gcc/testsuite/gcc.target/riscv/mcpu-2.c
@@ -1,0 +1,18 @@
+/* { dg-do compile } */
+/* { dg-skip-if "-march given" { *-*-* } { "-march=*" } } */
+/* { dg-options "-mcpu=sifive-e34 -mabi=ilp32" } */
+/* sifive-e34 = rv32imafc */
+
+#if !((__riscv_xlen == 32)		\
+      && !defined(__riscv_32e)		\
+      && defined(__riscv_mul)		\
+      && defined(__riscv_atomic)	\
+      && (__riscv_flen == 32)		\
+      && defined(__riscv_compressed))
+#error "unexpected arch"
+#endif
+
+int main()
+{
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/riscv/mcpu-3.c
+++ b/gcc/testsuite/gcc.target/riscv/mcpu-3.c
@@ -1,0 +1,18 @@
+/* { dg-do compile } */
+/* { dg-skip-if "-march given" { *-*-* } { "-march=*" } } */
+/* { dg-options "-mcpu=sifive-s51 -mabi=lp64" } */
+/* sifive-s51 = rv64imac */
+
+#if !((__riscv_xlen == 64)		\
+      && !defined(__riscv_32e)		\
+      && defined(__riscv_mul)		\
+      && defined(__riscv_atomic)	\
+      && !defined(__riscv_flen)		\
+      && defined(__riscv_compressed))
+#error "unexpected arch"
+#endif
+
+int main()
+{
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/riscv/mcpu-4.c
+++ b/gcc/testsuite/gcc.target/riscv/mcpu-4.c
@@ -1,0 +1,18 @@
+/* { dg-do compile } */
+/* { dg-skip-if "-march given" { *-*-* } { "-march=*" } } */
+/* { dg-options "-mcpu=sifive-u74 -mabi=lp64" } */
+/* sifive-u74 = rv64imafdc */
+
+#if !((__riscv_xlen == 64)		\
+      && !defined(__riscv_32e)		\
+      && defined(__riscv_mul)		\
+      && defined(__riscv_atomic)	\
+      && (__riscv_flen == 64)		\
+      && defined(__riscv_compressed))
+#error "unexpected arch"
+#endif
+
+int main()
+{
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/riscv/mcpu-5.c
+++ b/gcc/testsuite/gcc.target/riscv/mcpu-5.c
@@ -1,0 +1,19 @@
+/* { dg-do compile } */
+/* { dg-skip-if "-march given" { *-*-* } { "-march=*" } } */
+/* Verify -march will override arch option from -mcpu.  */
+/* { dg-options "-mcpu=sifive-u74 -march=rv32ic -mabi=ilp32" } */
+/* sifive-s51 = rv64imafdc */
+
+#if !((__riscv_xlen == 32)		\
+      && !defined(__riscv_32e)		\
+      && !defined(__riscv_mul)		\
+      && !defined(__riscv_atomic)	\
+      && !defined(__riscv_flen)		\
+      && defined(__riscv_compressed))
+#error "unexpected arch"
+#endif
+
+int main()
+{
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/riscv/mcpu-6.c
+++ b/gcc/testsuite/gcc.target/riscv/mcpu-6.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* Verify -mtune has higher priority than -mcpu for pipeline model .  */
+/* { dg-options "-mcpu=sifive-u74 -mtune=rocket -fdump-rtl-sched2-details -O3 -march=rv32i -mabi=ilp32" } */
+/* { dg-final { scan-rtl-dump "simple_return\[ \]+:alu" "sched2" } } */
+
+int main()
+{
+  return 0;
+}
+

--- a/gcc/testsuite/gcc.target/riscv/mcpu-7.c
+++ b/gcc/testsuite/gcc.target/riscv/mcpu-7.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* Verify -mtune has higher priority than -mcpu for pipeline model .  */
+/* { dg-options "-mcpu=sifive-s21 -mtune=sifive-u74 -fdump-rtl-sched2-details -O3 -march=rv32i -mabi=ilp32" } */
+/* { dg-final { scan-rtl-dump "simple_return\[ \]+:sifive_7_B" "sched2" } } */
+
+int main()
+{
+  return 0;
+}
+

--- a/gcc/testsuite/gcc.target/riscv/predef-3.c
+++ b/gcc/testsuite/gcc.target/riscv/predef-3.c
@@ -55,11 +55,11 @@ int main () {
 #if defined(__riscv_cmodel_medlow)
 #error "__riscv_cmodel_medlow"
 #endif
-#if defined(__riscv_cmodel_medany)
-#error "__riscv_cmodel_medlow"
+#if !defined(__riscv_cmodel_medany)
+#error "__riscv_cmodel_medany"
 #endif
 #if !defined(__riscv_cmodel_pic)
-#error "__riscv_cmodel_medlow"
+#error "__riscv_cmodel_pic"
 #endif
 
   return 0;

--- a/gcc/testsuite/gcc.target/riscv/predef-6.c
+++ b/gcc/testsuite/gcc.target/riscv/predef-6.c
@@ -55,11 +55,11 @@ int main () {
 #if defined(__riscv_cmodel_medlow)
 #error "__riscv_cmodel_medlow"
 #endif
-#if defined(__riscv_cmodel_medany)
-#error "__riscv_cmodel_medlow"
+#if !defined(__riscv_cmodel_medany)
+#error "__riscv_cmodel_medany"
 #endif
 #if !defined(__riscv_cmodel_pic)
-#error "__riscv_cmodel_medlow"
+#error "__riscv_cmodel_medpic"
 #endif
 
   return 0;

--- a/gcc/testsuite/gcc.target/riscv/shorten-memrefs-8.c
+++ b/gcc/testsuite/gcc.target/riscv/shorten-memrefs-8.c
@@ -1,0 +1,27 @@
+/* { dg-options "-Os -march=rv32imc -mabi=ilp32" } */
+
+/* shorten_memrefs should use a correct base address*/
+
+void
+store (char *p, int k)
+{
+  *(int *)(p + 17) = k;
+  *(int *)(p + 21) = k;
+  *(int *)(p + 25) = k;
+  *(int *)(p + 29) = k;
+}
+
+int
+load (char *p)
+{
+  int a = 0;
+  a += *(int *)(p + 17);
+  a += *(int *)(p + 21);
+  a += *(int *)(p + 25);
+  a += *(int *)(p + 29);
+  return a;
+}
+
+/* { dg-final { scan-assembler "store:\n\taddi\ta\[0-7\],a\[0-7\],1" } } */
+/* { dg-final { scan-assembler "load:\n\taddi\ta\[0-7\],a\[0-7\],1" } } */
+

--- a/gcc/testsuite/gfortran.dg/pr95690.f90
+++ b/gcc/testsuite/gfortran.dg/pr95690.f90
@@ -2,8 +2,8 @@
 module m
 contains
    subroutine s
-      print *, (erfc) ! { dg-error "not a floating constant" }
-   end
+      print *, (erfc) ! { dg-error "not a floating constant" "" { target i?86-*-* x86_64-*-* } }
+   end ! { dg-error "not a floating constant" "" { target { ! "i?86-*-* x86_64-*-*" } } }
    function erfc()
    end
 end


### PR DESCRIPTION
I implemented sub-extension parsing, but it has dependency on this patch: `RISC-V: Refine riscv_parse_arch_string`, so I think just merge from gcc 10.2.0 should be easier to maintain both tree. 