### PR TITLE
[RVB] Handle sub-extension and version info for B

### DIFF
--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -153,6 +153,129 @@ riscv_subset_list::~riscv_subset_list ()
     }
 }
 
+/* Get the rank for single-letter subsets, lower value meaning higher
+   priority.  */
+
+static int
+single_letter_subset_rank (char ext)
+{
+  int rank;
+
+  switch (ext)
+    {
+    case 'i':
+      return 0;
+    case 'e':
+      return 1;
+    default:
+      break;
+    }
+
+  const char *all_ext = riscv_supported_std_ext ();
+  const char *ext_pos = strchr (all_ext, ext);
+  if (ext_pos == NULL)
+    /* If got an unknown extension letter, then give it an alphabetical
+       order, but after all known standard extension.  */
+    rank = strlen (all_ext) + ext - 'a';
+  else
+    rank = (int)(ext_pos - all_ext) + 2 /* e and i has higher rank.  */;
+
+  return rank;
+}
+
+/* Get the rank for multi-letter subsets, lower value meaning higher
+   priority.  */
+
+static int
+multi_letter_subset_rank (const std::string &subset)
+{
+  gcc_assert (subset.length () >= 2);
+  int high_order = -1;
+  int low_order = 0;
+  /* The order between multi-char extensions: s -> h -> z -> x.  */
+  char multiletter_class = subset[0];
+  switch (multiletter_class)
+    {
+    case 's':
+      high_order = 0;
+      break;
+    case 'h':
+      high_order = 1;
+      break;
+    case 'z':
+      gcc_assert (subset.length () > 2);
+      high_order = 2;
+      break;
+    case 'x':
+      high_order = 3;
+      break;
+    default:
+      gcc_unreachable ();
+      return -1;
+    }
+
+  if (multiletter_class == 'z')
+    /* Order for z extension on spec: If multiple "Z" extensions are named, they
+       should be ordered first by category, then alphabetically within a
+       category - for example, "Zicsr_Zifencei_Zam". */
+    low_order = single_letter_subset_rank (subset[1]);
+  else
+    low_order = 0;
+
+  return (high_order << 8) + low_order;
+}
+
+/* subset compare
+
+  Returns an integral value indicating the relationship between the subsets:
+  Return value  indicates
+  -1            B has higher order than A.
+  0             A and B are same subset.
+  1             A has higher order than B.
+
+*/
+
+static int
+subset_cmp (const std::string &a, const std::string &b)
+{
+  if (a == b)
+    return 0;
+
+  size_t a_len = a.length ();
+  size_t b_len = b.length ();
+
+  /* Single-letter extension always get higher order than
+     multi-letter extension.  */
+  if (a_len == 1 && b_len != 1)
+    return 1;
+
+  if (a_len != 1 && b_len == 1)
+    return -1;
+
+  if (a_len == 1 && b_len == 1)
+    {
+      int rank_a = single_letter_subset_rank (a[0]);
+      int rank_b = single_letter_subset_rank (b[0]);
+
+      if (rank_a < rank_b)
+	return 1;
+      else
+	return -1;
+    }
+  else
+    {
+      int rank_a = multi_letter_subset_rank(a);
+      int rank_b = multi_letter_subset_rank(b);
+
+      /* Using alphabetical/lexicographical order if they have same rank.  */
+      if (rank_a == rank_b)
+	/* The return value of strcmp has opposite meaning.  */
+	return -strcmp (a.c_str (), b.c_str ());
+      else
+	return (rank_a < rank_b) ? 1 : -1;
+    }
+}
+
 /* Add new subset to list.  */
 
 void
@@ -160,6 +283,7 @@ riscv_subset_list::add (const char *subset, int major_version,
 			int minor_version, bool explicit_version_p)
 {
   riscv_subset_t *s = new riscv_subset_t ();
+  riscv_subset_t *itr;
 
   if (m_head == NULL)
     m_head = s;
@@ -170,9 +294,45 @@ riscv_subset_list::add (const char *subset, int major_version,
   s->explicit_version_p = explicit_version_p;
   s->next = NULL;
 
-  if (m_tail != NULL)
-    m_tail->next = s;
+  if (m_tail == NULL)
+    {
+      m_tail = s;
+      return;
+    }
 
+  /* e, i or g should be first subext, never come here.  */
+  gcc_assert (subset[0] != 'e'
+	      && subset[0] != 'i'
+	      && subset[0] != 'g');
+
+  if (m_tail == m_head)
+    {
+      gcc_assert (m_head->next == NULL);
+      m_head->next = s;
+      m_tail = s;
+      return;
+    }
+
+  gcc_assert (m_head->next != NULL);
+
+  /* Subset list must in canonical order, but implied subset won't
+     add in canonical order.  */
+  for (itr = m_head; itr->next != NULL; itr = itr->next)
+    {
+      riscv_subset_t *next = itr->next;
+      int cmp = subset_cmp (s->name, next->name);
+      gcc_assert (cmp != 0);
+
+      if (cmp > 0)
+	{
+	  s->next = next;
+	  itr->next = s;
+	  return;
+	}
+    }
+
+  /* Insert at tail of the list.  */
+  itr->next = s;
   m_tail = s;
 }
 
@@ -449,9 +609,6 @@ riscv_subset_list::parse_std_ext (const char *p)
 
       subset[0] = std_ext;
 
-      handle_implied_ext (subset, major_version,
-			  minor_version, explicit_version_p);
-
       add (subset, major_version, minor_version, explicit_version_p);
     }
   return p;
@@ -561,6 +718,7 @@ riscv_subset_list *
 riscv_subset_list::parse (const char *arch, location_t loc)
 {
   riscv_subset_list *subset_list = new riscv_subset_list (arch, loc);
+  riscv_subset_t *itr;
   const char *p = arch;
   if (strncmp (p, "rv32", 4) == 0)
     {
@@ -614,6 +772,15 @@ riscv_subset_list::parse (const char *arch, location_t loc)
       error_at (loc, "%<-march=%s%>: unexpected ISA string at end: %qs",
                arch, p);
       goto fail;
+    }
+
+  for (itr = subset_list->m_head; itr != NULL; itr = itr->next)
+    {
+      subset_list->handle_implied_ext (
+	itr->name.c_str (),
+	itr->major_version,
+	itr->minor_version,
+	itr->explicit_version_p);
     }
 
   return subset_list;

--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -44,6 +44,7 @@ struct riscv_subset_t
   struct riscv_subset_t *next;
 
   bool explicit_version_p;
+  bool implied_p;
 };
 
 /* Type for implied ISA info.  */
@@ -68,6 +69,58 @@ riscv_implied_info_t riscv_implied_info[] =
   {"b", "zbc"},
   {"b", "zbm"},
   {NULL, NULL}
+};
+
+/* This structure holds version information for specific ISA version.  */
+
+struct riscv_ext_version
+{
+  const char *name;
+  enum riscv_isa_spec_class isa_spec_class;
+  int major_version;
+  int minor_version;
+};
+
+/* All standard extensions defined in all supported ISA spec.  */
+static const struct riscv_ext_version riscv_ext_version_table[] =
+{
+  /* name, ISA spec, major version, minor_version.  */
+  {"e", ISA_SPEC_CLASS_20191213, 1, 9},
+  {"e", ISA_SPEC_CLASS_20190608, 1, 9},
+  {"e", ISA_SPEC_CLASS_2P2,      1, 9},
+
+  {"i", ISA_SPEC_CLASS_20191213, 2, 1},
+  {"i", ISA_SPEC_CLASS_20190608, 2, 1},
+  {"i", ISA_SPEC_CLASS_2P2,      2, 0},
+
+  {"m", ISA_SPEC_CLASS_20191213, 2, 0},
+  {"m", ISA_SPEC_CLASS_20190608, 2, 0},
+  {"m", ISA_SPEC_CLASS_2P2,      2, 0},
+
+  {"a", ISA_SPEC_CLASS_20191213, 2, 1},
+  {"a", ISA_SPEC_CLASS_20190608, 2, 0},
+  {"a", ISA_SPEC_CLASS_2P2,      2, 0},
+
+  {"f", ISA_SPEC_CLASS_20191213, 2, 2},
+  {"f", ISA_SPEC_CLASS_20190608, 2, 2},
+  {"f", ISA_SPEC_CLASS_2P2,      2, 0},
+
+  {"d", ISA_SPEC_CLASS_20191213, 2, 2},
+  {"d", ISA_SPEC_CLASS_20190608, 2, 2},
+  {"d", ISA_SPEC_CLASS_2P2,      2, 0},
+
+  {"c", ISA_SPEC_CLASS_20191213, 2, 0},
+  {"c", ISA_SPEC_CLASS_20190608, 2, 0},
+  {"c", ISA_SPEC_CLASS_2P2,      2, 0},
+
+  {"zicsr", ISA_SPEC_CLASS_20191213, 2, 0},
+  {"zicsr", ISA_SPEC_CLASS_20190608, 2, 0},
+
+  {"zifencei", ISA_SPEC_CLASS_20191213, 2, 0},
+  {"zifencei", ISA_SPEC_CLASS_20190608, 2, 0},
+
+  /* Terminate the list.  */
+  {NULL, ISA_SPEC_CLASS_NONE, 0, 0}
 };
 
 static const riscv_cpu_info riscv_cpu_tables[] =
@@ -99,20 +152,22 @@ private:
 
   riscv_subset_list (const char *, location_t);
 
-  const char *parsing_subset_version (const char *, unsigned *, unsigned *,
-				      unsigned, unsigned, bool, bool *);
+  const char *parsing_subset_version (const char *, const char *, unsigned *,
+				      unsigned *, bool, bool *);
 
   const char *parse_std_ext (const char *);
 
   const char *parse_multiletter_ext (const char *, const char *,
 				     const char *);
 
-  void handle_implied_ext (const char *, int, int, bool);
+  void handle_implied_ext (riscv_subset_t *);
 
 public:
   ~riscv_subset_list ();
 
-  void add (const char *, int, int, bool);
+  void add (const char *, int, int, bool, bool);
+
+  void add (const char *, bool);
 
   riscv_subset_t *lookup (const char *,
 			  int major_version = RISCV_DONT_CARE_VERSION,
@@ -132,7 +187,7 @@ static riscv_subset_list *current_subset_list = NULL;
 
 riscv_subset_t::riscv_subset_t ()
   : name (), major_version (0), minor_version (0), next (NULL),
-    explicit_version_p (false)
+    explicit_version_p (false), implied_p (false)
 {
 }
 
@@ -282,8 +337,31 @@ subset_cmp (const std::string &a, const std::string &b)
 
 void
 riscv_subset_list::add (const char *subset, int major_version,
-			int minor_version, bool explicit_version_p)
+			int minor_version, bool explicit_version_p,
+			bool implied_p)
 {
+  riscv_subset_t *ext = lookup (subset);
+
+  if (ext)
+    {
+      if (ext->implied_p)
+	{
+	  /* We won't add impiled `ext` if it already in list. */
+	  gcc_assert (!implied_p);
+	  ext->implied_p = implied_p;
+	  ext->major_version = major_version;
+	  ext->minor_version = minor_version;
+	}
+      else
+	error_at (
+	  m_loc,
+	  "%<-march=%s%>: Extension `%s' appear more than one time.",
+	  m_arch,
+	  subset);
+
+      return;
+    }
+
   riscv_subset_t *s = new riscv_subset_t ();
   riscv_subset_t *itr;
 
@@ -294,6 +372,7 @@ riscv_subset_list::add (const char *subset, int major_version,
   s->major_version = major_version;
   s->minor_version = minor_version;
   s->explicit_version_p = explicit_version_p;
+  s->implied_p = implied_p;
   s->next = NULL;
 
   if (m_tail == NULL)
@@ -338,6 +417,43 @@ riscv_subset_list::add (const char *subset, int major_version,
   m_tail = s;
 }
 
+static void
+get_default_version (const char *ext,
+		     unsigned int *major_version,
+		     unsigned int *minor_version)
+{
+  const riscv_ext_version *ext_ver;
+  for (ext_ver = &riscv_ext_version_table[0];
+       ext_ver->name != NULL;
+       ++ext_ver)
+    if (strcmp (ext, ext_ver->name) == 0)
+      {
+	if ((ext_ver->isa_spec_class == riscv_isa_spec) ||
+	    (ext_ver->isa_spec_class == ISA_SPEC_CLASS_NONE))
+	  {
+	    *major_version = ext_ver->major_version;
+	    *minor_version = ext_ver->minor_version;
+	    return;
+	  }
+      }
+
+  /* Not found version info.  */
+  *major_version = 0;
+  *minor_version = 0;
+}
+
+/* Add new subset to list, but using default version from ISA spec version.  */
+
+void
+riscv_subset_list::add (const char *subset, bool implied_p)
+{
+  unsigned int major_version = 0, minor_version = 0;
+
+  get_default_version (subset, &major_version, &minor_version);
+
+  add (subset, major_version, minor_version, false, implied_p);
+}
+
 /* Convert subset info to string with explicit version info,
    VERSION_P to determine append version info or not.  */
 
@@ -348,10 +464,37 @@ riscv_subset_list::to_string (bool version_p) const
   oss << "rv" << m_xlen;
 
   bool first = true;
-  riscv_subset_t *subset = m_head;
+  riscv_subset_t *subset;
 
-  while (subset != NULL)
+  bool skip_zifencei = false;
+  bool skip_zicsr = false;
+
+  /* For RISC-V ISA version 2.2 or earlier version, zicsr and zifencei is
+     included in the base ISA.  */
+  if (riscv_isa_spec == ISA_SPEC_CLASS_2P2)
     {
+      skip_zifencei = true;
+      skip_zicsr = true;
+    }
+
+#ifndef HAVE_AS_MISA_SPEC
+  /* Skip since older binutils doesn't recognize zicsr.  */
+  skip_zicsr = true;
+#endif
+#ifndef HAVE_AS_MARCH_ZIFENCE
+  /* Skip since older binutils doesn't recognize zifencei, we made
+     a mistake in that binutils 2.35 supports zicsr but not zifencei.  */
+  skip_zifencei = true;
+#endif
+
+  for (subset = m_head; subset != NULL; subset = subset->next)
+    {
+      if (subset->implied_p && skip_zifencei && subset->name == "zifencei")
+	continue;
+
+      if (subset->implied_p && skip_zicsr && subset->name == "zicsr")
+	continue;
+
       /* For !version_p, we only separate extension with underline for
 	 multi-letter extension.  */
       if (!first &&
@@ -363,12 +506,12 @@ riscv_subset_list::to_string (bool version_p) const
 
       oss << subset->name;
 
-      if (version_p || subset->explicit_version_p)
+      /* Let binutils decide the extension version if we don't know.  */
+      if ((version_p || subset->explicit_version_p) &&
+	  (subset->major_version != 0 || subset->minor_version != 0))
 	oss  << subset->major_version
 	     << 'p'
 	     << subset->minor_version;
-
-      subset = subset->next;
     }
 
   return oss.str ();
@@ -416,23 +559,21 @@ riscv_supported_std_ext (void)
      Points to the end of version
 
    Arguments:
+     `ext`: This extension.
      `p`: Current parsing position.
      `major_version`: Parsing result of major version, using
       default_major_version if version is not present in arch string.
      `minor_version`: Parsing result of minor version, set to 0 if version is
      not present in arch string, but set to `default_minor_version` if
      `major_version` using default_major_version.
-     `default_major_version`: Default major version.
-     `default_minor_version`: Default minor version.
      `std_ext_p`: True if parsing std extension.
      `explicit_version_p`: True if this subset is not using default version.  */
 
 const char *
-riscv_subset_list::parsing_subset_version (const char *p,
+riscv_subset_list::parsing_subset_version (const char *ext,
+					   const char *p,
 					   unsigned *major_version,
 					   unsigned *minor_version,
-					   unsigned default_major_version,
-					   unsigned default_minor_version,
 					   bool std_ext_p,
 					   bool *explicit_version_p)
 {
@@ -483,11 +624,7 @@ riscv_subset_list::parsing_subset_version (const char *p,
     minor = version;
 
   if (major == 0 && minor == 0)
-    {
-      /* We didn't find any version string, use default version.  */
-      *major_version = default_major_version;
-      *minor_version = default_minor_version;
-    }
+    get_default_version (ext, major_version, minor_version);
   else
     {
       *explicit_version_p = true;
@@ -521,23 +658,17 @@ riscv_subset_list::parse_std_ext (const char *p)
     {
     case 'i':
       p++;
-      p = parsing_subset_version (p, &major_version, &minor_version,
-				  /* default_major_version= */ 2,
-				  /* default_minor_version= */ 0,
-				  /* std_ext_p= */ true,
-				  &explicit_version_p);
-      add ("i", major_version, minor_version, explicit_version_p);
+      p = parsing_subset_version ("i", p, &major_version, &minor_version,
+				  /* std_ext_p= */ true, &explicit_version_p);
+      add ("i", major_version, minor_version, explicit_version_p, false);
       break;
 
     case 'e':
       p++;
-      p = parsing_subset_version (p, &major_version, &minor_version,
-				  /* default_major_version= */ 1,
-				  /* default_minor_version= */ 9,
-				  /* std_ext_p= */ true,
-				  &explicit_version_p);
+      p = parsing_subset_version ("e", p, &major_version, &minor_version,
+				  /* std_ext_p= */ true, &explicit_version_p);
 
-      add ("e", major_version, minor_version, explicit_version_p);
+      add ("e", major_version, minor_version, explicit_version_p, false);
 
       if (m_xlen > 32)
 	{
@@ -549,18 +680,26 @@ riscv_subset_list::parse_std_ext (const char *p)
 
     case 'g':
       p++;
-      p = parsing_subset_version (p, &major_version, &minor_version,
-				  /* default_major_version= */ 2,
-				  /* default_minor_version= */ 0,
-				  /* std_ext_p= */ true,
-				  &explicit_version_p);
-      add ("i", major_version, minor_version, explicit_version_p);
-
-      for (; *std_exts != 'q'; std_exts++)
+      p = parsing_subset_version ("g", p, &major_version, &minor_version,
+				  /* std_ext_p= */ true, &explicit_version_p);
+      if (major_version != 0 || minor_version != 0)
 	{
-	  const char subset[] = {*std_exts, '\0'};
-	  add (subset, major_version, minor_version, explicit_version_p);
+	  warning_at (m_loc, 0, "version of `g` will be omitted, please "
+				"specify version for individual extension.");
 	}
+
+      /* We have special rule for G, we disallow rv32gm2p but allow rv32g_zicsr
+	 here, basically we treating G expand to imafd and implied zicsr and
+	 zifencei.  */
+
+      add ("i", false);
+      add ("m", false);
+      add ("a", false);
+      add ("f", false);
+      add ("d", false);
+      add ("zicsr", true);
+      add ("zifencei", true);
+
       break;
 
     default:
@@ -603,44 +742,47 @@ riscv_subset_list::parse_std_ext (const char *p)
       std_exts++;
 
       p++;
-      p = parsing_subset_version (p, &major_version, &minor_version,
-				  /* default_major_version= */ 2,
-				  /* default_minor_version= */ 0,
-				  /* std_ext_p= */ true,
-				  &explicit_version_p);
-
       subset[0] = std_ext;
 
-      add (subset, major_version, minor_version, explicit_version_p);
+      p = parsing_subset_version (subset, p, &major_version, &minor_version,
+				  /* std_ext_p= */ true, &explicit_version_p);
+
+      add (subset, major_version, minor_version, explicit_version_p, false);
     }
   return p;
 }
 
 
-/* Check any implied extensions for EXT with version
-   MAJOR_VERSION.MINOR_VERSION, EXPLICIT_VERSION_P indicate the version is
-   explicitly given by user or not.  */
+/* Check any implied extensions for EXT.  */
 void
-riscv_subset_list::handle_implied_ext (const char *ext,
-				       int major_version,
-				       int minor_version,
-				       bool explicit_version_p)
+riscv_subset_list::handle_implied_ext (riscv_subset_t *ext)
 {
   riscv_implied_info_t *implied_info;
   for (implied_info = &riscv_implied_info[0];
        implied_info->ext;
        ++implied_info)
     {
-      if (strcmp (ext, implied_info->ext) != 0)
+      if (strcmp (ext->name.c_str (), implied_info->ext) != 0)
 	continue;
 
       /* Skip if implied extension already present.  */
       if (lookup (implied_info->implied_ext))
 	continue;
 
-      /* TODO: Implied extension might use different version.  */
-      add (implied_info->implied_ext, major_version, minor_version,
-	   explicit_version_p);
+      /* Version of implied extension will get from current ISA spec
+	 version.  */
+      add (implied_info->implied_ext, true);
+    }
+
+  /* For RISC-V ISA version 2.2 or earlier version, zicsr and zifence is
+     included in the base ISA.  */
+  if (riscv_isa_spec == ISA_SPEC_CLASS_2P2)
+    {
+      if (lookup ("zicsr") == NULL)
+	add ("zicsr", true);
+
+      if (lookup ("zifencei") == NULL)
+	add ("zifencei", true);
     }
 }
 
@@ -678,16 +820,21 @@ riscv_subset_list::parse_multiletter_ext (const char *p,
       char *q = subset;
       const char *end_of_version;
       bool explicit_version_p = false;
+      char *ext;
+      char backup;
 
       while (*++q != '\0' && *q != '_' && !ISDIGIT (*q))
 	;
 
+      backup = *q;
+      *q = '\0';
+      ext = xstrdup (subset);
+      *q = backup;
+
       end_of_version
-	= parsing_subset_version (q, &major_version, &minor_version,
-				  /* default_major_version= */ 2,
-				  /* default_minor_version= */ 0,
-				  /* std_ext_p= */ FALSE,
-				  &explicit_version_p);
+	= parsing_subset_version (ext, q, &major_version, &minor_version,
+				  /* std_ext_p= */ false, &explicit_version_p);
+      free (ext);
 
       *q = '\0';
 
@@ -699,7 +846,7 @@ riscv_subset_list::parse_multiletter_ext (const char *p,
 	  return NULL;
 	}
 
-      add (subset, major_version, minor_version, explicit_version_p);
+      add (subset, major_version, minor_version, explicit_version_p, false);
       free (subset);
       p += end_of_version - subset;
 
@@ -778,11 +925,7 @@ riscv_subset_list::parse (const char *arch, location_t loc)
 
   for (itr = subset_list->m_head; itr != NULL; itr = itr->next)
     {
-      subset_list->handle_implied_ext (
-	itr->name.c_str (),
-	itr->major_version,
-	itr->minor_version,
-	itr->explicit_version_p);
+      subset_list->handle_implied_ext (itr);
     }
 
   return subset_list;

--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -57,6 +57,14 @@ struct riscv_implied_info_t
 riscv_implied_info_t riscv_implied_info[] =
 {
   {"d", "f"},
+  {"b", "zbb"},
+  {"b", "zbs"},
+  {"b", "zba"},
+  {"b", "zbp"},
+  {"b", "zbe"},
+  {"b", "zbf"},
+  {"b", "zbc"},
+  {"b", "zbm"},
   {NULL, NULL}
 };
 
@@ -646,6 +654,16 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"d", &gcc_options::x_target_flags, MASK_DOUBLE_FLOAT},
   {"c", &gcc_options::x_target_flags, MASK_RVC},
   {"b", &gcc_options::x_target_flags, MASK_BITMANIP},
+  {"zba", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBA},
+  {"zbb", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBB},
+  {"zbs", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBS},
+  {"zbp", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBP},
+  {"zbr", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBP},
+  {"zbe", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBE},
+  {"zbf", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBF},
+  {"zbc", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBC},
+  {"zbm", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBM},
+  {"zbt", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBT},
   {NULL, NULL, 0}
 };
 

--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -57,6 +57,8 @@ struct riscv_implied_info_t
 riscv_implied_info_t riscv_implied_info[] =
 {
   {"d", "f"},
+  {"f", "zicsr"},
+  {"d", "zicsr"},
   {"b", "zbb"},
   {"b", "zbs"},
   {"b", "zba"},
@@ -821,6 +823,10 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"d", &gcc_options::x_target_flags, MASK_DOUBLE_FLOAT},
   {"c", &gcc_options::x_target_flags, MASK_RVC},
   {"b", &gcc_options::x_target_flags, MASK_BITMANIP},
+
+  {"zicsr",    &gcc_options::x_riscv_zi_subext, MASK_ZICSR},
+  {"zifencei", &gcc_options::x_riscv_zi_subext, MASK_ZIFENCEI},
+
   {"zba", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBA},
   {"zbb", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBB},
   {"zbs", &gcc_options::x_riscv_bitmanip_subext, MASK_ZBS},

--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -119,6 +119,17 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
   {"zifencei", ISA_SPEC_CLASS_20191213, 2, 0},
   {"zifencei", ISA_SPEC_CLASS_20190608, 2, 0},
 
+  {"b",   ISA_SPEC_CLASS_NONE, 0, 92},
+  {"zba", ISA_SPEC_CLASS_NONE, 0, 92},
+  {"zbb", ISA_SPEC_CLASS_NONE, 0, 92},
+  {"zbc", ISA_SPEC_CLASS_NONE, 0, 92},
+  {"zbe", ISA_SPEC_CLASS_NONE, 0, 92},
+  {"zbf", ISA_SPEC_CLASS_NONE, 0, 92},
+  {"zbr", ISA_SPEC_CLASS_NONE, 0, 92},
+  {"zbm", ISA_SPEC_CLASS_NONE, 0, 92},
+  {"zbs", ISA_SPEC_CLASS_NONE, 0, 92},
+  {"zbt", ISA_SPEC_CLASS_NONE, 0, 92},
+  {"zbp", ISA_SPEC_CLASS_NONE, 0, 92},
   /* Terminate the list.  */
   {NULL, ISA_SPEC_CLASS_NONE, 0, 0}
 };

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -4497,12 +4497,27 @@ case "${target}" in
 		;;
 
 	riscv*-*-*)
-		supported_defaults="abi arch tune riscv_attribute"
+		supported_defaults="abi arch tune riscv_attribute isa_spec"
 
 		case "${target}" in
 		riscv-* | riscv32*) xlen=32 ;;
 		riscv64*) xlen=64 ;;
 		*) echo "Unsupported RISC-V target ${target}" 1>&2; exit 1 ;;
+		esac
+
+		case "${with_isa_spec}" in
+		""|default|2.2)
+			tm_defines="${tm_defines} TARGET_DEFAULT_ISA_SPEC=ISA_SPEC_CLASS_2P2"
+			;;
+		20191213 | 201912)
+			tm_defines="${tm_defines} TARGET_DEFAULT_ISA_SPEC=ISA_SPEC_CLASS_20191213"
+			;;
+		20190608 | 201906)
+			tm_defines="${tm_defines} TARGET_DEFAULT_ISA_SPEC=ISA_SPEC_CLASS_20190608"
+			;;
+		*)
+			echo "--with-isa-spec only accept 2.2, 20191213, 201912, 20190608 or 201906" 1>&2
+			exit 1
 		esac
 
 		case "${with_riscv_attribute}" in

--- a/gcc/config.in
+++ b/gcc/config.in
@@ -643,6 +643,18 @@
 #endif
 
 
+/* Define if your assembler supports -misa-spec=. */
+#ifndef USED_FOR_TARGET
+#undef HAVE_AS_MISA_SPEC
+#endif
+
+
+/* Define if your assembler supports -march=rv*_zifencei. */
+#ifndef USED_FOR_TARGET
+#undef HAVE_AS_MARCH_ZIFENCEI
+#endif
+
+
 /* Define if your assembler supports relocs needed by -fpic. */
 #ifndef USED_FOR_TARGET
 #undef HAVE_AS_SMALL_PIC_RELOCS

--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -36,42 +36,42 @@
 (define_insn "clzsi2"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(clz:SI (match_operand:SI 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB"
   { return TARGET_64BIT ? "clzw\t%0,%1" : "clz\t%0,%1"; }
   [(set_attr "type" "bitmanip")])
 
 (define_insn "clzdi2"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(clz:DI (match_operand:DI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "clz\t%0,%1"
   [(set_attr "type" "bitmanip")])
 
 (define_insn "ctzsi2"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(ctz:SI (match_operand:SI 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB"
   { return TARGET_64BIT ? "ctzw\t%0,%1" : "ctz\t%0,%1"; }
   [(set_attr "type" "bitmanip")])
 
 (define_insn "ctzdi2"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(ctz:DI (match_operand:DI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "ctz\t%0,%1"
   [(set_attr "type" "bitmanip")])
 
 (define_insn "popcountsi2"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(popcount:SI (match_operand:SI 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB"
   { return TARGET_64BIT ? "pcntw\t%0,%1" : "pcnt\t%0,%1"; }
   [(set_attr "type" "bitmanip")])
 
 (define_insn "popcountdi2"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(popcount:DI (match_operand:DI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "pcnt\t%0,%1"
   [(set_attr "type" "bitmanip")])
 
@@ -79,7 +79,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(bitmanip_bitwise:X (not:X (match_operand:X 1 "register_operand" "r"))
 			    (match_operand:X 2 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB || TARGET_ZBP"
   "<insn>n\t%0,%2,%1"
   [(set_attr "type" "bitmanip")])
 
@@ -87,7 +87,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(not:X (xor:X (match_operand:X 1 "register_operand" "r")
 		      (match_operand:X 2 "register_operand" "r"))))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB || TARGET_ZBP"
   "xnor\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
  
@@ -97,7 +97,7 @@
 (define_insn "*zero_extendhi<GPR:mode>2_bitmanip"
   [(set (match_operand:GPR 0 "register_operand" "=r,r")
 	(zero_extend:GPR (match_operand:HI 1 "nonimmediate_operand" "r,m")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB || TARGET_ZBP"
 {
   if (which_alternative == 0)
    return TARGET_64BIT ? "packw\t%0,%1,x0" : "pack\t%0,%1,x0";
@@ -110,7 +110,7 @@
 (define_insn "*zero_extendsidi2_bitmanip"
   [(set (match_operand:DI 0 "register_operand" "=r,r")
 	(zero_extend:DI (match_operand:SI 1 "nonimmediate_operand" "r,m")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && (TARGET_ZBB || TARGET_ZBP)"
   "@
    pack\t%0,%1,x0
    lwu\t%0,%1"
@@ -120,7 +120,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(any_minmax:X (match_operand:X 1 "register_operand" "r")
 		      (match_operand:X 2 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB"
   "<bitmanip_insn>\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -129,7 +129,7 @@
 	(ior:X (ashift:X (const_int 1)
 			 (match_operand:QI 2 "register_operand" "r"))
 	       (match_operand:X 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbset\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -140,7 +140,7 @@
 			  (and:X (match_operand:X 2 "register_operand" "r")
 				 (match_operand 3 "<X:shiftm1>" "i")) 0))
 	       (match_operand:X 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbset\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -148,7 +148,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(ashift:X (const_int 1)
 		  (match_operand:QI 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbset\t%0,x0,%1"
   [(set_attr "type" "bitmanip")])
 
@@ -158,7 +158,7 @@
 		  (subreg:QI
 		   (and:X (match_operand:X 1 "register_operand" "r")
 			  (match_operand 2 "<X:shiftm1>" "i")) 0)))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbset\t%0,x0,%1"
   [(set_attr "type" "bitmanip")])
 
@@ -166,7 +166,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(ior:X (match_operand:X 1 "register_operand" "r")
 	       (match_operand 2 "single_bit_mask_operand" "i")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbseti\t%0,%1,%S2"
   [(set_attr "type" "bitmanip")])
 
@@ -178,7 +178,7 @@
 		   (ashift:SI (const_int 1)
 			      (match_operand:QI 2 "register_operand" "r")) 0)
 		  (match_operand:DI 1 "register_operand" "r")) 0)))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbsetw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -193,7 +193,7 @@
 		     (and:DI (match_operand:DI 2 "register_operand" "r")
 			     (match_operand 3 "const31_operand" "i")) 0)) 0)
 		  (match_operand:DI 1 "register_operand" "r")) 0)))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbsetw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -201,7 +201,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(ior:DI (sign_extend:DI (match_operand:SI 1 "register_operand" "r"))
 		(match_operand 2 "single_bit_mask_operand" "i")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbsetiw\t%0,%1,%S2"
   [(set_attr "type" "bitmanip")])
 
@@ -210,7 +210,7 @@
 	(and:X (rotate:X (const_int -2)
 			 (match_operand:QI 2 "register_operand" "r"))
 	       (match_operand:X 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbclr\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -218,7 +218,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(and:X (match_operand:X 1 "register_operand" "r")
 	       (match_operand 2 "not_single_bit_mask_operand" "i")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbclri\t%0,%1,%T2"
   [(set_attr "type" "bitmanip")])
 
@@ -231,7 +231,7 @@
 		    (ashift:SI (const_int 1)
 			       (match_operand:QI 2 "register_operand" "r")) 0))
 	   (match_operand:DI 1 "register_operand" "r")) 0)))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbclrw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -239,7 +239,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(and:DI (sign_extend:DI (match_operand:SI 1 "register_operand" "r"))
 		(match_operand 2 "not_single_bit_mask_operand" "i")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbclriw\t%0,%1,%T2"
   [(set_attr "type" "bitmanip")])
 
@@ -248,7 +248,7 @@
 	(xor:X (ashift:X (const_int 1)
 			 (match_operand:QI 2 "register_operand" "r"))
 	       (match_operand:X 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbinv\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -256,7 +256,7 @@
   [(set (match_operand:X 0 "register_operand" "=r")
 	(xor:X (match_operand:X 1 "register_operand" "r")
 	       (match_operand 2 "single_bit_mask_operand" "i")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbinvi\t%0,%1,%S2"
   [(set_attr "type" "bitmanip")])
 
@@ -268,7 +268,7 @@
 		   (ashift:SI (const_int 1)
 			      (match_operand:QI 2 "register_operand" "r")) 0)
 		  (match_operand:DI 1 "register_operand" "r")) 0)))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbinvw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -276,7 +276,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(xor:DI (sign_extend:DI (match_operand:SI 1 "register_operand" "r"))
 		(match_operand 2 "single_bit_mask_operand" "i")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbinviw\t%0,%1,%S2"
   [(set_attr "type" "bitmanip")])
 
@@ -286,7 +286,7 @@
 			(const_int 1)
 			(zero_extend:X
 			 (match_operand:QI 2 "register_operand" "r"))))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbext\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -295,7 +295,7 @@
 	(zero_extract:X (match_operand:X 1 "register_operand" "r")
 			(const_int 1)
 			(match_operand 2 "immediate_operand" "i")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBS"
   "sbexti\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -306,7 +306,7 @@
 	  (lshiftrt:SI (match_operand:SI 1 "register_operand" "r")
 		       (match_operand:QI 2 "register_operand" "r")) 0)
 	 (const_int 1)))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBS"
   "sbextw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -316,7 +316,7 @@
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(rotatert:SI (match_operand:SI 1 "register_operand" "r")
 		     (match_operand:QI 2 "arith_operand" "rI")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB || TARGET_ZBP"
   { return TARGET_64BIT ? "ror%i2w\t%0,%1,%2" : "ror%i2\t%0,%1,%2"; }
   [(set_attr "type" "bitmanip")])
 
@@ -324,7 +324,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(rotatert:DI (match_operand:DI 1 "register_operand" "r")
 		     (match_operand:QI 2 "arith_operand" "rI")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && (TARGET_ZBB || TARGET_ZBP)"
   "ror%i2\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -332,7 +332,7 @@
   [(match_operand:SI 0 "register_operand" "=r")
    (match_operand:SI 1 "register_operand" "r")
    (match_operand:SI 2 "register_operand" "r")]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && (TARGET_ZBB || TARGET_ZBP)"
 {
   emit_insn (gen_rotlsi3 (operands[0], operands[1], operands[2]));
   DONE;
@@ -342,7 +342,7 @@
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(rotate:SI (match_operand:SI 1 "register_operand" "r")
 		   (match_operand:QI 2 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBB || TARGET_ZBP"
   { return TARGET_64BIT ? "rolw\t%0,%1,%2" : "rol\t%0,%1,%2"; }
   [(set_attr "type" "bitmanip")])
 
@@ -350,7 +350,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(rotate:DI (match_operand:DI 1 "register_operand" "r")
 		   (match_operand:QI 2 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && (TARGET_ZBB || TARGET_ZBP)"
   "rol\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -358,7 +358,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(sign_extend:DI (rotate:SI (match_operand:SI 1 "register_operand" "r")
 				   (match_operand:QI 2 "register_operand" "r"))))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && (TARGET_ZBB || TARGET_ZBP)"
   "rolw\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -368,7 +368,7 @@
 (define_insn "bswapsi2"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(bswap:SI (match_operand:SI 1 "register_operand" "r")))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBP"
   { return TARGET_64BIT ? "greviw\t%0,%1,0x18" : "grevi\t%0,%1,0x18"; }
   [(set_attr "type" "bitmanip")])
 
@@ -376,7 +376,7 @@
 (define_insn "bswapdi2"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(bswap:DI (match_operand:DI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBP"
   "grevi\t%0,%1,0x38"
   [(set_attr "type" "bitmanip")])
 
@@ -396,7 +396,7 @@
 			     (match_operand:X 3 "register_operand" "r"))
 		      (match_operand:X 2 "register_operand" "r"))
 	       (match_dup 3)))]
-  "TARGET_BITMANIP"
+  "TARGET_ZBT"
   "cmix\t%0,%2,%1,%3"
   [(set_attr "type" "bitmanip")])
 
@@ -409,7 +409,7 @@
 	(plus:X (ashift:X (match_operand:X 1 "register_operand" "r")
 			  (match_operand:QI 2 "immediate_operand" "I"))
 		(match_operand:X 3 "register_operand" "r")))]
-  "TARGET_BITMANIP
+  "TARGET_ZBA
    && (INTVAL (operands[2]) >= 1) && (INTVAL (operands[2]) <= 3)"
   "sh%2add\t%0,%1,%3"
   [(set_attr "type" "bitmanip")])
@@ -421,7 +421,7 @@
 			    (match_operand:QI 2 "immediate_operand" "I"))
 		 (match_operand 3 "immediate_operand" ""))
 	 (match_operand:DI 4 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP
+  "TARGET_64BIT && TARGET_ZBA
    && (INTVAL (operands[2]) >= 1) && (INTVAL (operands[2]) <= 3)
    && (INTVAL (operands[3]) >> INTVAL (operands[2])) == 0xffffffff"
   "sh%2addu.w\t%0,%1,%4"
@@ -431,7 +431,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(zero_extend:DI (plus:SI (match_operand:SI 1 "register_operand" "r")
 				 (match_operand:SI 2 "arith_operand" "rI"))))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "add%i2wu\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -439,7 +439,7 @@
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(zero_extend:DI (minus:SI (match_operand:SI 1 "register_operand" "r")
 				  (match_operand:SI 2 "register_operand" "r"))))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBA"
   "subwu\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -448,7 +448,7 @@
 	(plus:DI (zero_extend:DI
 		  (subreg:SI (match_operand:DI 2 "register_operand" "r") 0))
 		 (match_operand:DI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "addu.w\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -457,7 +457,7 @@
 	(minus:DI (match_operand:DI 1 "register_operand" "r")
 		  (zero_extend:DI
 		   (subreg:SI (match_operand:DI 2 "register_operand" "r") 0))))]
-  "TARGET_64BIT && TARGET_BITMANIP"
+  "TARGET_64BIT && TARGET_ZBB"
   "subu.w\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -466,7 +466,7 @@
 	(and:DI (ashift:DI (match_operand:DI 1 "register_operand" "r")
 			   (match_operand:QI 2 "immediate_operand" "I"))
 		(match_operand 3 "immediate_operand" "")))]
-  "TARGET_64BIT && TARGET_BITMANIP
+  "TARGET_64BIT && TARGET_ZBB
    && (INTVAL (operands[3]) >> INTVAL (operands[2])) == 0xffffffff"
   "slliu.w\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])

--- a/gcc/config/riscv/riscv-opts.h
+++ b/gcc/config/riscv/riscv-opts.h
@@ -39,6 +39,16 @@ enum riscv_code_model {
 };
 extern enum riscv_code_model riscv_cmodel;
 
+enum riscv_isa_spec_class {
+  ISA_SPEC_CLASS_NONE,
+
+  ISA_SPEC_CLASS_2P2,
+  ISA_SPEC_CLASS_20190608,
+  ISA_SPEC_CLASS_20191213
+};
+
+extern enum riscv_isa_spec_class riscv_isa_spec;
+
 /* Keep this list in sync with define_attr "tune" in riscv.md.  */
 enum riscv_microarchitecture_type {
   generic,

--- a/gcc/config/riscv/riscv-opts.h
+++ b/gcc/config/riscv/riscv-opts.h
@@ -51,4 +51,26 @@ enum riscv_align_data {
   riscv_align_data_type_natural
 };
 
+#define MASK_ZBA (1 << 0)
+#define MASK_ZBB (1 << 1)
+#define MASK_ZBS (1 << 2)
+#define MASK_ZBP (1 << 3)
+#define MASK_ZBE (1 << 4)
+#define MASK_ZBF (1 << 5)
+#define MASK_ZBC (1 << 6)
+#define MASK_ZBR (1 << 7)
+#define MASK_ZBM (1 << 8)
+#define MASK_ZBT (1 << 9)
+
+#define TARGET_ZBA ((riscv_bitmanip_subext & MASK_ZBA) != 0)
+#define TARGET_ZBB ((riscv_bitmanip_subext & MASK_ZBB) != 0)
+#define TARGET_ZBS ((riscv_bitmanip_subext & MASK_ZBS) != 0)
+#define TARGET_ZBP ((riscv_bitmanip_subext & MASK_ZBP) != 0)
+#define TARGET_ZBE ((riscv_bitmanip_subext & MASK_ZBE) != 0)
+#define TARGET_ZBF ((riscv_bitmanip_subext & MASK_ZBF) != 0)
+#define TARGET_ZBC ((riscv_bitmanip_subext & MASK_ZBC) != 0)
+#define TARGET_ZBR ((riscv_bitmanip_subext & MASK_ZBR) != 0)
+#define TARGET_ZBM ((riscv_bitmanip_subext & MASK_ZBM) != 0)
+#define TARGET_ZBT ((riscv_bitmanip_subext & MASK_ZBT) != 0)
+
 #endif /* ! GCC_RISCV_OPTS_H */

--- a/gcc/config/riscv/riscv-opts.h
+++ b/gcc/config/riscv/riscv-opts.h
@@ -73,4 +73,10 @@ enum riscv_align_data {
 #define TARGET_ZBM ((riscv_bitmanip_subext & MASK_ZBM) != 0)
 #define TARGET_ZBT ((riscv_bitmanip_subext & MASK_ZBT) != 0)
 
+#define MASK_ZICSR    (1 << 0)
+#define MASK_ZIFENCEI (1 << 1)
+
+#define TARGET_ZICSR    ((riscv_zi_subext & MASK_ZICSR) != 0)
+#define TARGET_ZIFENCEI ((riscv_zi_subext & MASK_ZIFENCEI) != 0)
+
 #endif /* ! GCC_RISCV_OPTS_H */

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -70,13 +70,20 @@ extern const char *riscv_default_mtune (int argc, const char **argv);
 #define TARGET_64BIT           (__riscv_xlen == 64)
 #endif /* IN_LIBGCC2 */
 
+#ifdef HAVE_AS_MISA_SPEC
+#define ASM_MISA_SPEC "%{misa-spec=*}"
+#else
+#define ASM_MISA_SPEC ""
+#endif
+
 #undef ASM_SPEC
 #define ASM_SPEC "\
 %(subtarget_asm_debugging_spec) \
 %{" FPIE_OR_FPIC_SPEC ":-fpic} \
 %{march=*} \
 %{mabi=*} \
-%(subtarget_asm_spec)"
+%(subtarget_asm_spec)" \
+ASM_MISA_SPEC
 
 #undef DRIVER_SELF_SPECS
 #define DRIVER_SELF_SPECS					\

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1550,7 +1550,8 @@
 		     LCT_NORMAL, VOIDmode, operands[0], Pmode,
 		     operands[1], Pmode, const0_rtx, Pmode);
 #else
-  emit_insn (gen_fence_i ());
+  if (TARGET_ZIFENCEI)
+    emit_insn (gen_fence_i ());
 #endif
   DONE;
 })
@@ -1562,7 +1563,7 @@
 
 (define_insn "fence_i"
   [(unspec_volatile [(const_int 0)] UNSPECV_FENCE_I)]
-  ""
+  "TARGET_ZIFENCEI"
   "fence.i")
 
 ;;

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -157,3 +157,6 @@ Enum(riscv_align_data) String(xlen) Value(riscv_align_data_type_xlen)
 
 EnumValue
 Enum(riscv_align_data) String(natural) Value(riscv_align_data_type_natural)
+
+TargetVariable
+int riscv_bitmanip_subext

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -163,3 +163,20 @@ int riscv_bitmanip_subext
 
 TargetVariable
 int riscv_zi_subext
+
+Enum
+Name(isa_spec_class) Type(enum riscv_isa_spec_class)
+Supported ISA specs (for use with the -misa-spec= option):
+
+EnumValue
+Enum(isa_spec_class) String(2.2) Value(ISA_SPEC_CLASS_2P2)
+
+EnumValue
+Enum(isa_spec_class) String(20190608) Value(ISA_SPEC_CLASS_20190608)
+
+EnumValue
+Enum(isa_spec_class) String(20191213) Value(ISA_SPEC_CLASS_20191213)
+
+misa-spec=
+Target Report RejectNegative Joined Enum(isa_spec_class) Var(riscv_isa_spec) Init(TARGET_DEFAULT_ISA_SPEC)
+Set the version of RISC-V ISA spec.

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -160,3 +160,6 @@ Enum(riscv_align_data) String(natural) Value(riscv_align_data_type_natural)
 
 TargetVariable
 int riscv_bitmanip_subext
+
+TargetVariable
+int riscv_zi_subext

--- a/gcc/configure
+++ b/gcc/configure
@@ -28109,6 +28109,68 @@ $as_echo "#define HAVE_AS_RISCV_ATTRIBUTE 1" >>confdefs.h
 
 fi
 
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking assembler for -misa-spec= support" >&5
+$as_echo_n "checking assembler for -misa-spec= support... " >&6; }
+if ${gcc_cv_as_riscv_isa_spec+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  gcc_cv_as_riscv_isa_spec=no
+  if test x$gcc_cv_as != x; then
+    $as_echo '' > conftest.s
+    if { ac_try='$gcc_cv_as $gcc_cv_as_flags -misa-spec=2.2 -o conftest.o conftest.s >&5'
+  { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_try\""; } >&5
+  (eval $ac_try) 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; }
+    then
+	gcc_cv_as_riscv_isa_spec=yes
+    else
+      echo "configure: failed program was" >&5
+      cat conftest.s >&5
+    fi
+    rm -f conftest.o conftest.s
+  fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $gcc_cv_as_riscv_isa_spec" >&5
+$as_echo "$gcc_cv_as_riscv_isa_spec" >&6; }
+if test $gcc_cv_as_riscv_isa_spec = yes; then
+
+$as_echo "#define HAVE_AS_MISA_SPEC 1" >>confdefs.h
+
+fi
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking assembler for -march=rv32i_zifencei support" >&5
+$as_echo_n "checking assembler for -march=rv32i_zifencei support... " >&6; }
+if ${gcc_cv_as_riscv_march_zifencei+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  gcc_cv_as_riscv_march_zifencei=no
+  if test x$gcc_cv_as != x; then
+    $as_echo '' > conftest.s
+    if { ac_try='$gcc_cv_as $gcc_cv_as_flags -march=rv32i_zifencei -o conftest.o conftest.s >&5'
+  { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_try\""; } >&5
+  (eval $ac_try) 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; }
+    then
+	gcc_cv_as_riscv_march_zifencei=yes
+    else
+      echo "configure: failed program was" >&5
+      cat conftest.s >&5
+    fi
+    rm -f conftest.o conftest.s
+  fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $gcc_cv_as_riscv_march_zifencei" >&5
+$as_echo "$gcc_cv_as_riscv_march_zifencei" >&6; }
+if test $gcc_cv_as_riscv_march_zifencei = yes; then
+
+$as_echo "#define HAVE_AS_MARCH_ZIFENCEI 1" >>confdefs.h
+
+fi
+
     ;;
     s390*-*-*)
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking assembler for .gnu_attribute support" >&5

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -5088,6 +5088,16 @@ configured with --enable-newlib-nano-formatted-io.])
       [.attribute stack_align,4],,
       [AC_DEFINE(HAVE_AS_RISCV_ATTRIBUTE, 1,
 	  [Define if your assembler supports .attribute.])])
+    gcc_GAS_CHECK_FEATURE([-misa-spec= support],
+      gcc_cv_as_riscv_isa_spec,,
+      [-misa-spec=2.2],,,
+      [AC_DEFINE(HAVE_AS_MISA_SPEC, 1,
+		 [Define if the assembler understands -misa-spec=.])])
+    gcc_GAS_CHECK_FEATURE([-march=rv32i_zifencei support],
+      gcc_cv_as_riscv_march_zifencei,,
+      [-march=rv32i_zifencei],,,
+      [AC_DEFINE(HAVE_AS_MARCH_ZIFENCEI, 1,
+		 [Define if the assembler understands -march=rv*_zifencei.])])
     ;;
     s390*-*-*)
     gcc_GAS_CHECK_FEATURE([.gnu_attribute support],

--- a/gcc/testsuite/gcc.target/riscv/arch-10.c
+++ b/gcc/testsuite/gcc.target/riscv/arch-10.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -march=rv32gf2 -mabi=ilp32" } */
+int foo()
+{
+}
+/* { dg-error "Extension `f' appear more than one time." "" { target *-*-* } 0 } */

--- a/gcc/testsuite/gcc.target/riscv/arch-11.c
+++ b/gcc/testsuite/gcc.target/riscv/arch-11.c
@@ -1,0 +1,5 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -march=rv32g_zicsr2 -mabi=ilp32" } */
+int foo()
+{
+}

--- a/gcc/testsuite/gcc.target/riscv/arch-8.c
+++ b/gcc/testsuite/gcc.target/riscv/arch-8.c
@@ -1,0 +1,5 @@
+/* { dg-do compile } */
+/* { dg-options "-O -march=rv32id_zicsr_zifence -mabi=ilp32" } */
+int foo()
+{
+}

--- a/gcc/testsuite/gcc.target/riscv/arch-9.c
+++ b/gcc/testsuite/gcc.target/riscv/arch-9.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -march=rv32g2 -mabi=ilp32" } */
+int foo()
+{
+}
+/* { dg-warning "version of `g` will be omitted, please specify version for individual extension." "" { target *-*-* } 0 } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-11.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-11.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O -mriscv-attribute -march=rv32id -mabi=ilp32" } */
+/* { dg-options "-O -mriscv-attribute -march=rv32id -mabi=ilp32 -misa-spec=2.2" } */
 int foo()
 {
 }

--- a/gcc/testsuite/gcc.target/riscv/attribute-12.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-12.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O -mriscv-attribute -march=rv32ifd -mabi=ilp32" } */
+/* { dg-options "-O -mriscv-attribute -march=rv32ifd -mabi=ilp32 -misa-spec=2.2" } */
 int foo()
 {
 }

--- a/gcc/testsuite/gcc.target/riscv/attribute-13.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-13.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O -mriscv-attribute -march=rv32if3d -mabi=ilp32" } */
+/* { dg-options "-O -mriscv-attribute -march=rv32if3d -mabi=ilp32 -misa-spec=2.2" } */
 int foo()
 {
 }

--- a/gcc/testsuite/gcc.target/riscv/attribute-14.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-14.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
-/* { dg-options "-O -mriscv-attribute -march=rv32if -mabi=ilp32" } */
+/* { dg-options "-O -mriscv-attribute -march=rv32if -mabi=ilp32 -misa-spec=20190608" } */
 int foo()
 {
 }
-/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p0_f2p0_zicsr2p0\"" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_f2p2_zicsr2p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-14.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-14.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-O -mriscv-attribute -march=rv32if -mabi=ilp32" } */
+int foo()
+{
+}
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p0_f2p0_zicsr2p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-15.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-15.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-O -mriscv-attribute -march=rv32gc -mabi=ilp32 -misa-spec=2.2" } */
+int foo()
+{
+}
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p0_m2p0_a2p0_f2p0_d2p0_c2p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-16.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-16.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-O -mriscv-attribute -march=rv32gc -mabi=ilp32 -misa-spec=20190608" } */
+int foo()
+{
+}
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_m2p0_a2p0_f2p2_d2p2_c2p0_zicsr2p0" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-17.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-17.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-O -mriscv-attribute -march=rv32gc -mabi=ilp32 -misa-spec=20191213" } */
+int foo()
+{
+}
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-6.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-6.c
@@ -1,6 +1,0 @@
-/* { dg-do compile } */
-/* { dg-options "-O -mriscv-attribute -march=rv32g2p0 -mabi=ilp32" } */
-int foo()
-{
-}
-/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p0_m2p0_a2p0_f2p0_d2p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-8.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-8.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
-/* { dg-options "-O -mriscv-attribute -march=rv32i2p0xv5_xabc -mabi=ilp32" } */
+/* { dg-options "-O -mriscv-attribute -march=rv32i2p0xabc_xv5 -mabi=ilp32" } */
 int foo()
 {
 }
-/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p0_xv5p0_xabc2p0\"" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p0_xabc_xv5p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-9.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-9.c
@@ -3,4 +3,4 @@
 int foo()
 {
 }
-/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p0_sabc2p0_xbar2p0\"" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p0_sabc_xbar\"" } } */


### PR DESCRIPTION
This patch-set enable the separated switch for each sub-extensions, and emit the right version info for all B-extension family, also back-port 3 necessary patch from upstream.

This PR and binuitls's PR https://github.com/riscv/riscv-binutils-gdb/pull/239 should made everything work correctly.

