### PR TITLE
Fixing vmv_s_x/vmv_x_s for rv32gcv

### DIFF
--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -950,7 +950,7 @@
 		      (reg:SI VL_REGNUM)]
 		    UNSPEC_USEVL))
 	      (use (reg:<VLMODE> VTYPE_REGNUM))])]
-  "TARGET_VECTOR && TARGET_64BIT"
+  "TARGET_VECTOR"
 {
 })
 
@@ -963,7 +963,7 @@
 	   (reg:SI VL_REGNUM)]
 	 UNSPEC_USEVL))
    (use (reg:<VLMODE> VTYPE_REGNUM))]
-  "TARGET_VECTOR && TARGET_64BIT"
+  "TARGET_VECTOR"
   "vmv.x.s\t%0,%1"
   [(set_attr "type" "vector")
    (set_attr "mode" "none")])
@@ -980,7 +980,7 @@
 		      (reg:SI VL_REGNUM)]
 		    UNSPEC_USEVL))
 	      (use (reg:<VLMODE> VTYPE_REGNUM))])]
-  "TARGET_VECTOR && TARGET_64BIT"
+  "TARGET_VECTOR"
 {
 })
 
@@ -995,7 +995,7 @@
 	   (reg:SI VL_REGNUM)]
 	 UNSPEC_USEVL))
    (use (reg:<VLMODE> VTYPE_REGNUM))]
-  "TARGET_VECTOR && TARGET_64BIT"
+  "TARGET_VECTOR"
   "vmv.s.x\t%0,%2"
   [(set_attr "type" "vector")
    (set_attr "mode" "none")])

--- a/gcc/testsuite/gcc.target/riscv/rvv/github-pr779.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/github-pr779.c
@@ -1,0 +1,11 @@
+/* { dg-do compile } */
+/* { dg-additional-options "-march=rv32gcv -mabi=ilp32" } */
+
+#include <riscv_vector.h>
+int32_t x_to_s(int32_t i)
+{
+   vint32m8_t v;
+   v    = vmv_s_x_i32m8(v, i);
+   return vmv_x_s_i32m8_i32(v);
+}
+


### PR DESCRIPTION
Fix https://github.com/riscv/riscv-gnu-toolchain/issues/779, not sure why we put the TARGET_64BIT in the pattern condition, 
I guess one possible is we don't know how to handle 64-bits vector-scalar operations yet, but block all ELEN would be too strong.

So let remove the TARGET_64BIT check at this moment.