### PR TITLE
[riscv-bitmanip] Fix condition check, using sub-extension as predicate.

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -438,7 +438,7 @@
 	(plus:DI (zero_extend:DI
 		  (subreg:SI (match_operand:DI 2 "register_operand" "r") 0))
 		 (match_operand:DI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_ZBB"
+  "TARGET_64BIT && TARGET_ZBA"
   "addu.w\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])
 
@@ -456,7 +456,7 @@
 	(and:DI (ashift:DI (match_operand:DI 1 "register_operand" "r")
 			   (match_operand:QI 2 "immediate_operand" "I"))
 		(match_operand 3 "immediate_operand" "")))]
-  "TARGET_64BIT && TARGET_ZBB
+  "TARGET_64BIT && TARGET_ZBA
    && (INTVAL (operands[3]) >> INTVAL (operands[2])) == 0xffffffff"
   "slliu.w\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])

--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -83,26 +83,21 @@
  
 ;;; ??? pack
 
-;; ??? assembler doesn't support zext.h
 (define_insn "*zero_extendhi<GPR:mode>2_bitmanip"
   [(set (match_operand:GPR 0 "register_operand" "=r,r")
 	(zero_extend:GPR (match_operand:HI 1 "nonimmediate_operand" "r,m")))]
   "TARGET_ZBB || TARGET_ZBP"
-{
-  if (which_alternative == 0)
-   return TARGET_64BIT ? "packw\t%0,%1,x0" : "pack\t%0,%1,x0";
-  else
-   return "lhu\t%0,%1";
-}
+  "@
+   zext.h\t%0,%1
+   lhu\t%0,%1"
   [(set_attr "type" "bitmanip,load")])
 
-;; ??? assembler doesn't support zext.w
 (define_insn "*zero_extendsidi2_bitmanip"
   [(set (match_operand:DI 0 "register_operand" "=r,r")
 	(zero_extend:DI (match_operand:SI 1 "nonimmediate_operand" "r,m")))]
   "TARGET_64BIT && (TARGET_ZBB || TARGET_ZBP)"
   "@
-   pack\t%0,%1,x0
+   zext.w\t%0,%1,x0
    lwu\t%0,%1"
   [(set_attr "type" "bitmanip,load")])
 

--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -74,12 +74,20 @@
   if (GET_MODE_SIZE (mode) > UNITS_PER_WORD)
     return false;
 
+  /* Check whether the constant can be loaded in a single
+     instruction with zb* extensions.  */
+  if (TARGET_64BIT)
+    {
+      if (TARGET_ZBS && SINGLE_BIT_MASK_OPERAND (INTVAL (op)))
+	return false;
+
+      if (TARGET_ZBB && ZERO_EXTENDED_SMALL_OPERAND (INTVAL (op)))
+	return false;
+    }
+
   /* Otherwise check whether the constant can be loaded in a single
      instruction.  */
-  return (!LUI_OPERAND (INTVAL (op)) && !SMALL_OPERAND (INTVAL (op))
-	  && !(TARGET_64BIT && TARGET_BITMANIP
-	       && (ZERO_EXTENDED_SMALL_OPERAND (INTVAL (op))
-		   || SINGLE_BIT_MASK_OPERAND (INTVAL (op)))));
+  return !LUI_OPERAND (INTVAL (op)) && !SMALL_OPERAND (INTVAL (op));
 })
 
 (define_predicate "p2m1_shift_operand"

--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -75,15 +75,9 @@
     return false;
 
   /* Check whether the constant can be loaded in a single
-     instruction with zb* extensions.  */
-  if (TARGET_64BIT)
-    {
-      if (TARGET_ZBS && SINGLE_BIT_MASK_OPERAND (INTVAL (op)))
-	return false;
-
-      if (TARGET_ZBB && ZERO_EXTENDED_SMALL_OPERAND (INTVAL (op)))
-	return false;
-    }
+     instruction with zbs extensions.  */
+  if (TARGET_64BIT && TARGET_ZBS && SINGLE_BIT_MASK_OPERAND (INTVAL (op)))
+    return false;
 
   /* Otherwise check whether the constant can be loaded in a single
      instruction.  */

--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -392,13 +392,6 @@ riscv_build_integer_1 (struct riscv_integer_op codes[RISCV_MAX_INTEGER_OPS],
      constants?  */
   if (TARGET_64BIT)
     {
-      if (TARGET_ZBB && ZERO_EXTENDED_SMALL_OPERAND (value))
-	{
-	  /* Simply ADDIWU.  */
-	  codes[0].code = UNKNOWN;
-	  codes[0].value = value;
-	  return 1;
-	}
       if (TARGET_ZBS && SINGLE_BIT_MASK_OPERAND (value))
 	{
 	  /* Simply SBSET.  */
@@ -2098,13 +2091,9 @@ riscv_output_move (rtx dest, rtx src)
 	  if (SMALL_OPERAND (INTVAL (src)) || LUI_OPERAND (INTVAL (src)))
 	    return "li\t%0,%1";
 
-	  if (TARGET_64BIT)
-	    {
-	      if (TARGET_ZBS && SINGLE_BIT_MASK_OPERAND (INTVAL (src)))
-		return "sbseti\t%0,zero,%S1";
-	      if (TARGET_ZBB && (ZERO_EXTENDED_SMALL_OPERAND (INTVAL (src))))
-		return "addiwu\t%0,zero,%s1";
-	    }
+	  if (TARGET_64BIT && TARGET_ZBS
+	      && SINGLE_BIT_MASK_OPERAND (INTVAL (src)))
+	    return "sbseti\t%0,zero,%S1";
 
 	  /* Should never reach here.  */
 	  abort ();

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -501,12 +501,6 @@ enum reg_class
 
 /* The following macros use B extension instructions to load constants.  */
 
-/* If this is a negative 32-bit value zero-extended to 64-bits, then we
-   can load it with addiwu if it is close enough to -1.  */
-#define ZERO_EXTENDED_SMALL_OPERAND(VALUE) \
-  (((VALUE & 0xffffffff) == VALUE) && (VALUE & 0x80000000)		\
-   && SMALL_OPERAND (VALUE | (0xffffffffUL << 32)))
-
 /* If this is a single bit mask, then we can load it with sbseti.  But this
    is not useful for any of the low 31 bits because we can use addi or lui
    to load them.  It is wrong for loading SImode 0x80000000 on rv64 because it

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1064,7 +1064,7 @@
   [(set (match_operand:DI     0 "register_operand"     "=r,r")
 	(zero_extend:DI
 	    (match_operand:SI 1 "nonimmediate_operand" " r,m")))]
-  "TARGET_64BIT && !(TARGET_ZBB || TARGET_ZBP)"
+  "TARGET_64BIT && !(TARGET_ZBA || TARGET_ZBB)"
   "@
    #
    lwu\t%0,%1"
@@ -1087,7 +1087,7 @@
   [(set (match_operand:GPR    0 "register_operand"     "=r,r")
 	(zero_extend:GPR
 	    (match_operand:HI 1 "nonimmediate_operand" " r,m")))]
-  "!(TARGET_ZBB || TARGET_ZBP)"
+  "!(TARGET_ZBA || TARGET_ZBB)"
   "@
    #
    lhu\t%0,%1"
@@ -1840,7 +1840,7 @@
 			   (match_operand:QI 2 "immediate_operand" "I"))
 		(match_operand 3 "immediate_operand" "")))
    (clobber (match_scratch:DI 4 "=&r"))]
-  "TARGET_64BIT && !(TARGET_ZBB || TARGET_ZBP)
+  "TARGET_64BIT && !(TARGET_ZBA || TARGET_ZBB)
    && ((INTVAL (operands[3]) >> INTVAL (operands[2])) == 0xffffffff)"
   "#"
   "&& reload_completed"

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1064,7 +1064,7 @@
   [(set (match_operand:DI     0 "register_operand"     "=r,r")
 	(zero_extend:DI
 	    (match_operand:SI 1 "nonimmediate_operand" " r,m")))]
-  "TARGET_64BIT && !TARGET_BITMANIP"
+  "TARGET_64BIT && !(TARGET_ZBB || TARGET_ZBP)"
   "@
    #
    lwu\t%0,%1"
@@ -1087,7 +1087,7 @@
   [(set (match_operand:GPR    0 "register_operand"     "=r,r")
 	(zero_extend:GPR
 	    (match_operand:HI 1 "nonimmediate_operand" " r,m")))]
-  "!TARGET_BITMANIP"
+  "!(TARGET_ZBB || TARGET_ZBP)"
   "@
    #
    lhu\t%0,%1"
@@ -1840,7 +1840,7 @@
 			   (match_operand:QI 2 "immediate_operand" "I"))
 		(match_operand 3 "immediate_operand" "")))
    (clobber (match_scratch:DI 4 "=&r"))]
-  "TARGET_64BIT && !TARGET_BITMANIP
+  "TARGET_64BIT && !(TARGET_ZBB || TARGET_ZBP)
    && ((INTVAL (operands[3]) >> INTVAL (operands[2])) == 0xffffffff)"
   "#"
   "&& reload_completed"

--- a/gcc/testsuite/gcc.target/riscv/rvb-li-rori.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-li-rori.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64gcb -mabi=lp64 -O2" } */
+/* { dg-options "-march=rv64gc_zbb -mabi=lp64 -O2" } */
 
 /* Expect li -126 and rori. */
 long

--- a/gcc/testsuite/gcc.target/riscv/rvb-sbxiw.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-sbxiw.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64gcb -mabi=lp64 -O2" } */
+/* { dg-options "-march=rv64gc_zbs -mabi=lp64 -O2" } */
 
 int foo1(int x, int y){
     return (x + y)| 0x8000;

--- a/gcc/testsuite/gcc.target/riscv/rvb-shNadd-01.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-shNadd-01.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64gcb -mabi=lp64 -O2" } */
+/* { dg-options "-march=rv64gc_zba -mabi=lp64 -O2" } */
 
 long test_1(long a, long b)
 {

--- a/gcc/testsuite/gcc.target/riscv/rvb-shNadd-02.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-shNadd-02.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32gcb -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32gc_zba -mabi=ilp32 -O2" } */
 
 long test_1(long a, long b)
 {

--- a/gcc/testsuite/gcc.target/riscv/rvb-shNadd-03.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-shNadd-03.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64gcb -mabi=lp64 -O2" } */
+/* { dg-options "-march=rv64gc_zba -mabi=lp64 -O2" } */
 
 /* RV64 only.  */
 int foos(short *x, int n){

--- a/gcc/testsuite/gcc.target/riscv/rvb-slliuw.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-slliuw.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64gcb -mabi=lp64 -O2" } */
+/* { dg-options "-march=rv64gc_zbb -mabi=lp64 -O2" } */
 
 long
 foo (long i)

--- a/gcc/testsuite/gcc.target/riscv/rvb-slliuw.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-slliuw.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64gc_zbb -mabi=lp64 -O2" } */
+/* { dg-options "-march=rv64gc_zba -mabi=lp64 -O2" } */
 
 long
 foo (long i)

--- a/gcc/testsuite/gcc.target/riscv/rvb-zbb-min-max.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-zbb-min-max.c
@@ -1,0 +1,31 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gc_zbb -mabi=lp64 -O2" } */
+
+long
+f1 (long i, long j)
+{
+  return i < j ? i : j;
+}
+
+long
+f2 (long i, long j)
+{
+  return i > j ? i : j;
+}
+
+unsigned long
+f3 (unsigned long i, unsigned long j)
+{
+  return i < j ? i : j;
+}
+
+unsigned long
+f4 (unsigned long i, unsigned long j)
+{
+  return i > j ? i : j;
+}
+
+/* { dg-final { scan-assembler-times "min\t" 1 } } */
+/* { dg-final { scan-assembler-times "max\t" 1 } } */
+/* { dg-final { scan-assembler-times "minu\t" 1 } } */
+/* { dg-final { scan-assembler-times "maxu\t" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/rvb-zbbw.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-zbbw.c
@@ -1,0 +1,25 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gc_zbb -mabi=lp64 -O2" } */
+
+int
+clz (int i)
+{
+  return __builtin_clz (i);
+}
+
+int
+ctz (int i)
+{
+  return __builtin_ctz (i);
+}
+
+int
+popcount (int i)
+{
+  return __builtin_popcount (i);
+}
+
+
+/* { dg-final { scan-assembler-times "clzw" 1 } } */
+/* { dg-final { scan-assembler-times "ctzw" 1 } } */
+/* { dg-final { scan-assembler-times "pcntw" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/rvb-zbs-set.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-zbs-set.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64gcb -mabi=lp64 -O2" } */
+/* { dg-options "-march=rv64gc_zbs -mabi=lp64 -O2" } */
 
 /* sbset */
 long


### PR DESCRIPTION
We found an issue is using `-march=rv64gcb` will get better result than using `-march=rv64gcb_zba_zbb_zbs`, it turns out we checking `TARGET_BITMANIP` rather than individual sub-extension, so even you use `-march=rv64gc_zba_zbb_zbc_zbe_zbf_zbs_zbp` still get worse result than `-march=rv64gcb`.

So in this patch we remove all `TARGET_BITMANIP`, using `TARGET_ZB*` instead.
