### PR TITLE
[riscv-bitmanip] Fix the operand order of addu.w

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -415,8 +415,8 @@
 (define_insn "*addu.w"
   [(set (match_operand:DI 0 "register_operand" "=r")
 	(plus:DI (zero_extend:DI
-		  (match_operand:SI 2 "register_operand" "r"))
-		 (match_operand:DI 1 "register_operand" "r")))]
+		  (match_operand:SI 1 "register_operand" "r"))
+		 (match_operand:DI 2 "register_operand" "r")))]
   "TARGET_64BIT && TARGET_ZBA"
   "addu.w\t%0,%1,%2"
   [(set_attr "type" "bitmanip")])


### PR DESCRIPTION
 - The operand order has been updated in spec:
https://github.com/riscv/riscv-bitmanip/commit/84b6fd847308ec0fe8143996787bf4f7fead5211