### PR TITLE
The epilogue restores the wrong stack space

### DIFF
--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -4302,7 +4302,7 @@ riscv_gen_load_poly_int (rtx target, rtx tmp1, rtx tmp2, poly_int64 value)
 	return gen_add3_insn (target, target, GEN_INT (scalar_offset));
       else
 	{
-	  rtx remainder = riscv_add_offset (target, target, scalar_offset);
+	  rtx remainder = riscv_add_offset (tmp2, target, scalar_offset);
 	  return gen_rtx_SET (target, remainder);
 	}
     }

--- a/gcc/testsuite/g++.target/riscv/rvv-large-stack.C
+++ b/gcc/testsuite/g++.target/riscv/rvv-large-stack.C
@@ -1,0 +1,26 @@
+/* { dg-do compile } */
+/* { dg-options "-O0 -march=rv64gcv -mabi=lp64d" } */
+
+#include <riscv_vector.h>
+#include <random>
+
+__attribute__((noinline)) void NestedFunc(vbool32_t a, vbool32_t b) {
+  return;
+}
+
+__attribute__((noinline)) void Crash() {
+  std::mt19937 rng;
+  const vuint32m1_t v0 = vmv_v_x_u32m1(0);
+  const vbool32_t mask = vmseq_vv_u32m1_b32(v0, v0);
+  NestedFunc(mask, mask);
+}
+
+int main() {
+  Crash();
+  return 0;
+}
+
+/* { dg-final { scan-assembler "mul\tt0,t0,t2" } } */
+/* { dg-final { scan-assembler "li\tt2,-4096" } } */
+/* { dg-final { scan-assembler "add\tt2,t2,t0" } } */
+/* { dg-final { scan-assembler "addi\tt0,t2,1552" } } */


### PR DESCRIPTION
The issue come form fredoom-tools in [pr76](https://github.com/sifive/freedom-tools/issues/76).
The issue happened in the epilogue of Crash function, 
and compiler will generate following ASM:

```
csrr    t0,vlenb
li      t2,-4
mul     t0,t0,t2
li      t0,-4096  //This insn overwrites the t0 register of the previous insn
add     t0,t0,t0
addi    t0,t0,1552
add     sp,s0,t0
```

To resolve this issue, I use t2 register be a temp register for li instruction.
So the ASM will be changed:

```
csrr    t0,vlenb
li      t2,-4
mul     t0,t0,t2
li      t2,-4096
add     t2,t2,t0
addi    t0,t2,1552
add     sp,s0,t0
```
