### PR TITLE
Improve cmix support, handle switched operands.

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -385,6 +385,18 @@
   "cmix\t%0,%2,%1,%3"
   [(set_attr "type" "bitmanip")])
 
+;; ??? Can we do this by using the % communtative constraint?
+
+(define_insn "*cmix2"
+  [(set (match_operand:X 0 "register_operand" "=r")
+	(xor:X (and:X (xor:X (match_operand:X 1 "register_operand" "r")
+			     (match_operand:X 3 "register_operand" "r"))
+		      (match_operand:X 2 "register_operand" "r"))
+	       (match_dup 1)))]
+  "TARGET_ZBT"
+  "cmix\t%0,%2,%3,%1"
+  [(set_attr "type" "bitmanip")])
+
 ;;; ??? cmov
 
 ;;; ??? fs[lr]


### PR DESCRIPTION
Given this testcase
long cmix (long i, long j, long k) { return (i & j) | (k & ~j); }
long cmix2 (long i, long j, long k) { return i ^ (j & (i ^ k)); }
long cmix3 (long i, long j, long k) { return i ^ (j & (k ^ i)); }
and compiling with zbt enabled we only generate cmix for 2 of the 3 functions.  This patch gives us cmix for all 3 testcases.

Minimally tested.
