### PR TITLE
[crypto] add instructions in K-ext spec v0.9.0

### DIFF
--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -237,7 +237,7 @@ riscv_subset_list::lookup (const char *subset, int major_version,
 static const char *
 riscv_supported_std_ext (void)
 {
-  return "mafdqlcbjtpvn";
+  return "mafdqlcbjktpvn";
 }
 
 /* Parsing subset version.
@@ -589,6 +589,12 @@ riscv_subset_list::parse (const char *arch, location_t loc)
   if (p == NULL)
     goto fail;
 
+  /* Parsing crypto extension.  */
+  p = subset_list->parse_multiletter_ext (p, "k", "crypto extension");
+
+  if (p == NULL)
+    goto fail;
+
   /* Parsing sub-extensions.  */
   p = subset_list->parse_multiletter_ext (p, "z", "sub-extension");
 
@@ -645,6 +651,19 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"f", &gcc_options::x_target_flags, MASK_HARD_FLOAT},
   {"d", &gcc_options::x_target_flags, MASK_DOUBLE_FLOAT},
   {"c", &gcc_options::x_target_flags, MASK_RVC},
+
+  {"k", &gcc_options::x_riscv_crypto_subext, MASK_ZKNE | MASK_ZKND | MASK_ZKNH | MASK_ZKG | MASK_ZKB | MASK_ZKR},
+  {"zkg", &gcc_options::x_riscv_crypto_subext, MASK_ZKG},
+  {"zkb", &gcc_options::x_riscv_crypto_subext, MASK_ZKB},
+  {"zkr", &gcc_options::x_riscv_crypto_subext, MASK_ZKR},
+  {"zkn", &gcc_options::x_riscv_crypto_subext, MASK_ZKNE | MASK_ZKND | MASK_ZKNH | MASK_ZKG | MASK_ZKB},
+  {"zkne", &gcc_options::x_riscv_crypto_subext, MASK_ZKNE},
+  {"zknd", &gcc_options::x_riscv_crypto_subext, MASK_ZKND},
+  {"zknh", &gcc_options::x_riscv_crypto_subext, MASK_ZKNH},
+  {"zks", &gcc_options::x_riscv_crypto_subext, MASK_ZKSED | MASK_ZKSH | MASK_ZKG | MASK_ZKB},
+  {"zksed", &gcc_options::x_riscv_crypto_subext, MASK_ZKSED},
+  {"zksh", &gcc_options::x_riscv_crypto_subext, MASK_ZKSH},
+
   {NULL, NULL, 0}
 };
 

--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -145,6 +145,129 @@ riscv_subset_list::~riscv_subset_list ()
     }
 }
 
+/* Get the rank for single-letter subsets, lower value meaning higher
+   priority.  */
+
+static int
+single_letter_subset_rank (char ext)
+{
+  int rank;
+
+  switch (ext)
+    {
+    case 'i':
+      return 0;
+    case 'e':
+      return 1;
+    default:
+      break;
+    }
+
+  const char *all_ext = riscv_supported_std_ext ();
+  const char *ext_pos = strchr (all_ext, ext);
+  if (ext_pos == NULL)
+    /* If got an unknown extension letter, then give it an alphabetical
+       order, but after all known standard extension.  */
+    rank = strlen (all_ext) + ext - 'a';
+  else
+    rank = (int)(ext_pos - all_ext) + 2 /* e and i has higher rank.  */;
+
+  return rank;
+}
+
+/* Get the rank for multi-letter subsets, lower value meaning higher
+   priority.  */
+
+static int
+multi_letter_subset_rank (const std::string &subset)
+{
+  gcc_assert (subset.length () >= 2);
+  int high_order = -1;
+  int low_order = 0;
+  /* The order between multi-char extensions: s -> h -> z -> x.  */
+  char multiletter_class = subset[0];
+  switch (multiletter_class)
+    {
+    case 's':
+      high_order = 0;
+      break;
+    case 'h':
+      high_order = 1;
+      break;
+    case 'z':
+      gcc_assert (subset.length () > 2);
+      high_order = 2;
+      break;
+    case 'x':
+      high_order = 3;
+      break;
+    default:
+      gcc_unreachable ();
+      return -1;
+    }
+
+  if (multiletter_class == 'z')
+    /* Order for z extension on spec: If multiple "Z" extensions are named, they
+       should be ordered first by category, then alphabetically within a
+       category - for example, "Zicsr_Zifencei_Zam". */
+    low_order = single_letter_subset_rank (subset[1]);
+  else
+    low_order = 0;
+
+  return (high_order << 8) + low_order;
+}
+
+/* subset compare
+
+  Returns an integral value indicating the relationship between the subsets:
+  Return value  indicates
+  -1            B has higher order than A.
+  0             A and B are same subset.
+  1             A has higher order than B.
+
+*/
+
+static int
+subset_cmp (const std::string &a, const std::string &b)
+{
+  if (a == b)
+    return 0;
+
+  size_t a_len = a.length ();
+  size_t b_len = b.length ();
+
+  /* Single-letter extension always get higher order than
+     multi-letter extension.  */
+  if (a_len == 1 && b_len != 1)
+    return 1;
+
+  if (a_len != 1 && b_len == 1)
+    return -1;
+
+  if (a_len == 1 && b_len == 1)
+    {
+      int rank_a = single_letter_subset_rank (a[0]);
+      int rank_b = single_letter_subset_rank (b[0]);
+
+      if (rank_a < rank_b)
+	return 1;
+      else
+	return -1;
+    }
+  else
+    {
+      int rank_a = multi_letter_subset_rank(a);
+      int rank_b = multi_letter_subset_rank(b);
+
+      /* Using alphabetical/lexicographical order if they have same rank.  */
+      if (rank_a == rank_b)
+	/* The return value of strcmp has opposite meaning.  */
+	return -strcmp (a.c_str (), b.c_str ());
+      else
+	return (rank_a < rank_b) ? 1 : -1;
+    }
+}
+
 /* Add new subset to list.  */
 
 void
@@ -152,6 +275,7 @@ riscv_subset_list::add (const char *subset, int major_version,
 			int minor_version, bool explicit_version_p)
 {
   riscv_subset_t *s = new riscv_subset_t ();
+  riscv_subset_t *itr;
 
   if (m_head == NULL)
     m_head = s;
@@ -162,9 +286,45 @@ riscv_subset_list::add (const char *subset, int major_version,
   s->explicit_version_p = explicit_version_p;
   s->next = NULL;
 
-  if (m_tail != NULL)
-    m_tail->next = s;
+  if (m_tail == NULL)
+    {
+      m_tail = s;
+      return;
+    }
 
+  /* e, i or g should be first subext, never come here.  */
+  gcc_assert (subset[0] != 'e'
+	      && subset[0] != 'i'
+	      && subset[0] != 'g');
+
+  if (m_tail == m_head)
+    {
+      gcc_assert (m_head->next == NULL);
+      m_head->next = s;
+      m_tail = s;
+      return;
+    }
+
+  gcc_assert (m_head->next != NULL);
+
+  /* Subset list must in canonical order, but implied subset won't
+     add in canonical order.  */
+  for (itr = m_head; itr->next != NULL; itr = itr->next)
+    {
+      riscv_subset_t *next = itr->next;
+      int cmp = subset_cmp (s->name, next->name);
+      gcc_assert (cmp != 0);
+
+      if (cmp > 0)
+	{
+	  s->next = next;
+	  itr->next = s;
+	  return;
+	}
+    }
+
+  /* Insert at tail of the list.  */
+  itr->next = s;
   m_tail = s;
 }
 
@@ -441,9 +601,6 @@ riscv_subset_list::parse_std_ext (const char *p)
 
       subset[0] = std_ext;
 
-      handle_implied_ext (subset, major_version,
-			  minor_version, explicit_version_p);
-
       add (subset, major_version, minor_version, explicit_version_p);
     }
   return p;
@@ -553,6 +710,7 @@ riscv_subset_list *
 riscv_subset_list::parse (const char *arch, location_t loc)
 {
   riscv_subset_list *subset_list = new riscv_subset_list (arch, loc);
+  riscv_subset_t *itr;
   const char *p = arch;
   if (strncmp (p, "rv32", 4) == 0)
     {
@@ -612,6 +770,15 @@ riscv_subset_list::parse (const char *arch, location_t loc)
       error_at (loc, "%<-march=%s%>: unexpected ISA string at end: %qs",
                arch, p);
       goto fail;
+    }
+
+  for (itr = subset_list->m_head; itr != NULL; itr = itr->next)
+    {
+      subset_list->handle_implied_ext (
+	itr->name.c_str (),
+	itr->major_version,
+	itr->minor_version,
+	itr->explicit_version_p);
     }
 
   return subset_list;

--- a/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/common/config/riscv/riscv-common.c
@@ -57,6 +57,17 @@ struct riscv_implied_info_t
 riscv_implied_info_t riscv_implied_info[] =
 {
   {"d", "f"},
+  {"k", "zkn"},
+  {"k", "zkr"},
+  {"zkn", "zkne"},
+  {"zkn", "zknd"},
+  {"zkn", "zknh"},
+  {"zkn", "zkg"},
+  {"zkn", "zkb"},
+  {"zks", "zksed"},
+  {"zks", "zksh"},
+  {"zks", "zkg"},
+  {"zks", "zkb"},
   {NULL, NULL}
 };
 
@@ -747,12 +758,6 @@ riscv_subset_list::parse (const char *arch, location_t loc)
   if (p == NULL)
     goto fail;
 
-  /* Parsing crypto extension.  */
-  p = subset_list->parse_multiletter_ext (p, "k", "crypto extension");
-
-  if (p == NULL)
-    goto fail;
-
   /* Parsing sub-extensions.  */
   p = subset_list->parse_multiletter_ext (p, "z", "sub-extension");
 
@@ -819,15 +824,12 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"d", &gcc_options::x_target_flags, MASK_DOUBLE_FLOAT},
   {"c", &gcc_options::x_target_flags, MASK_RVC},
 
-  {"k", &gcc_options::x_riscv_crypto_subext, MASK_ZKNE | MASK_ZKND | MASK_ZKNH | MASK_ZKG | MASK_ZKB | MASK_ZKR},
   {"zkg", &gcc_options::x_riscv_crypto_subext, MASK_ZKG},
   {"zkb", &gcc_options::x_riscv_crypto_subext, MASK_ZKB},
   {"zkr", &gcc_options::x_riscv_crypto_subext, MASK_ZKR},
-  {"zkn", &gcc_options::x_riscv_crypto_subext, MASK_ZKNE | MASK_ZKND | MASK_ZKNH | MASK_ZKG | MASK_ZKB},
   {"zkne", &gcc_options::x_riscv_crypto_subext, MASK_ZKNE},
   {"zknd", &gcc_options::x_riscv_crypto_subext, MASK_ZKND},
   {"zknh", &gcc_options::x_riscv_crypto_subext, MASK_ZKNH},
-  {"zks", &gcc_options::x_riscv_crypto_subext, MASK_ZKSED | MASK_ZKSH | MASK_ZKG | MASK_ZKB},
   {"zksed", &gcc_options::x_riscv_crypto_subext, MASK_ZKSED},
   {"zksh", &gcc_options::x_riscv_crypto_subext, MASK_ZKSH},
 

--- a/gcc/config/riscv/crypto.md
+++ b/gcc/config/riscv/crypto.md
@@ -1,5 +1,5 @@
 ;; Machine description for K extension.
-;; Copyright (C) 2011-2021 Free Software Foundation, Inc.
+;; Copyright (C) 2021 Free Software Foundation, Inc.
 
 ;; This file is part of GCC.
 
@@ -18,106 +18,119 @@
 ;; <http://www.gnu.org/licenses/>.
 
 
+(define_c_enum "unspec" [
+  ;; Crypto extension unspecs.
+  UNSPEC_AES_DS
+  UNSPEC_AES_DSM
+  UNSPEC_AES_ES
+  UNSPEC_AES_ESM
+  UNSPEC_AES_K
+  UNSPEC_SHA_256_SIG0
+  UNSPEC_SHA_256_SIG1
+  UNSPEC_SHA_256_SUM0
+  UNSPEC_SHA_256_SUM1
+  UNSPEC_SHA_512_SIG0
+  UNSPEC_SHA_512_SIG1
+  UNSPEC_SHA_512_SUM0
+  UNSPEC_SHA_512_SUM1
+  UNSPEC_SM3_P0
+  UNSPEC_SM3_P1
+  UNSPEC_SM4_ED
+  UNSPEC_SM4_KS
+  UNSPEC_POLLENTROPY
+  UNSPEC_GETNOISE
+])
+
+
 ;; Zkne&Zknd - AES (RV32)
 
 (define_insn "riscv_aes32dsi"
   [(set (match_operand:SI 0 "register_operand" "=r")
-    (unspec:SI
-      [(match_operand:SI 1 "register_operand" "r")
-        (match_operand:SI 2 "immediate_operand" "")]
-        UNSPEC_CRYPTO))]
+        (unspec:SI [(match_operand:SI 1 "register_operand" "r")
+                   (match_operand:SI 2 "immediate_operand" "")]
+                   UNSPEC_AES_DS))]
   "TARGET_ZKND && !TARGET_64BIT"
   "aes32dsi\t%0,%1,%2")
 
 (define_insn "riscv_aes32dsmi"
   [(set (match_operand:SI 0 "register_operand" "=r")
-    (unspec:SI
-      [(match_operand:SI 1 "register_operand" "r")
-        (match_operand:SI 2 "immediate_operand" "")]
-        UNSPEC_CRYPTO))]
+        (unspec:SI [(match_operand:SI 1 "register_operand" "r")
+                   (match_operand:SI 2 "immediate_operand" "")]
+                   UNSPEC_AES_DSM))]
   "TARGET_ZKND && !TARGET_64BIT"
   "aes32dsmi\t%0,%1,%2")
 
 (define_insn "riscv_aes32esi"
   [(set (match_operand:SI 0 "register_operand" "=r")
-    (unspec:SI
-      [(match_operand:SI 1 "register_operand" "r")
-        (match_operand:SI 2 "immediate_operand" "")]
-        UNSPEC_CRYPTO))]
+        (unspec:SI [(match_operand:SI 1 "register_operand" "r")
+                   (match_operand:SI 2 "immediate_operand" "")]
+                   UNSPEC_AES_ES))]
   "TARGET_ZKNE && !TARGET_64BIT"
   "aes32esi\t%0,%1,%2")
 
 (define_insn "riscv_aes32esmi"
   [(set (match_operand:SI 0 "register_operand" "=r")
-    (unspec:SI
-      [(match_operand:SI 1 "register_operand" "r")
-        (match_operand:SI 2 "immediate_operand" "")]
-        UNSPEC_CRYPTO))]
+        (unspec:SI [(match_operand:SI 1 "register_operand" "r")
+                   (match_operand:SI 2 "immediate_operand" "")]
+                   UNSPEC_AES_ESM))]
   "TARGET_ZKNE && !TARGET_64BIT"
   "aes32esmi\t%0,%1,%2")
 
 
-;; Zkne&Zknd - AES(RV64)
+;; Zkne&Zknd - AES (RV64)
 
 (define_insn "riscv_aes64ds"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")
-        (match_operand:DI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")
+                   (match_operand:DI 2 "register_operand" "r")]
+                   UNSPEC_AES_DS))]
   "TARGET_ZKND && TARGET_64BIT"
   "aes64ds\t%0,%1,%2")
 
 (define_insn "riscv_aes64dsm"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")
-        (match_operand:DI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")
+                   (match_operand:DI 2 "register_operand" "r")]
+                   UNSPEC_AES_DSM))]
   "TARGET_ZKND && TARGET_64BIT"
   "aes64dsm\t%0,%1,%2")
 
 (define_insn "riscv_aes64es"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")
-        (match_operand:DI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")
+                   (match_operand:DI 2 "register_operand" "r")]
+                   UNSPEC_AES_ES))]
   "TARGET_ZKNE && TARGET_64BIT"
   "aes64es\t%0,%1,%2")
 
 (define_insn "riscv_aes64esm"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")
-        (match_operand:DI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")
+                   (match_operand:DI 2 "register_operand" "r")]
+                   UNSPEC_AES_ESM))]
   "TARGET_ZKNE && TARGET_64BIT"
   "aes64esm\t%0,%1,%2")
 
 (define_insn "riscv_aes64im"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")]
+                   UNSPEC_AES_K))]
   "TARGET_ZKND && TARGET_64BIT"
   "aes64im\t%0,%1")
 
 (define_insn "riscv_aes64ks1i"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")
-        (match_operand:DI 2 "immediate_operand" "")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")
+                   (match_operand:DI 2 "immediate_operand" "")]
+                   UNSPEC_AES_K))]
   "TARGET_ZKNE && TARGET_64BIT"
   "aes64ks1i\t%0,%1,%2")
 
 (define_insn "riscv_aes64ks2"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")
-        (match_operand:DI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")
+                   (match_operand:DI 2 "register_operand" "r")]
+                   UNSPEC_AES_K))]
   "TARGET_ZKNE && TARGET_64BIT"
   "aes64ks2\t%0,%1,%2")
 
@@ -126,33 +139,29 @@
 
 (define_insn "riscv_sha256sig0_<mode>"
   [(set (match_operand:X 0 "register_operand" "=r")
-    (unspec:X
-      [(match_operand:X 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:X [(match_operand:X 1 "register_operand" "r")]
+                  UNSPEC_SHA_256_SIG0))]
   "TARGET_ZKNH"
   "sha256sig0\t%0,%1")
 
 (define_insn "riscv_sha256sig1_<mode>"
   [(set (match_operand:X 0 "register_operand" "=r")
-    (unspec:X
-      [(match_operand:X 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:X [(match_operand:X 1 "register_operand" "r")]
+                  UNSPEC_SHA_256_SIG1))]
   "TARGET_ZKNH"
   "sha256sig1\t%0,%1")
 
 (define_insn "riscv_sha256sum0_<mode>"
   [(set (match_operand:X 0 "register_operand" "=r")
-    (unspec:X
-      [(match_operand:X 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:X [(match_operand:X 1 "register_operand" "r")]
+                  UNSPEC_SHA_256_SUM0))]
   "TARGET_ZKNH"
   "sha256sum0\t%0,%1")
 
 (define_insn "riscv_sha256sum1_<mode>"
   [(set (match_operand:X 0 "register_operand" "=r")
-    (unspec:X
-      [(match_operand:X 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:X [(match_operand:X 1 "register_operand" "r")]
+                  UNSPEC_SHA_256_SUM1))]
   "TARGET_ZKNH"
   "sha256sum1\t%0,%1")
 
@@ -161,55 +170,49 @@
 
 (define_insn "riscv_sha512sig0h"
   [(set (match_operand:SI 0 "register_operand" "=r")
-    (unspec:SI
-      [(match_operand:SI 1 "register_operand" "r")
-        (match_operand:SI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:SI [(match_operand:SI 1 "register_operand" "r")
+                   (match_operand:SI 2 "register_operand" "r")]
+                   UNSPEC_SHA_512_SIG0))]
   "TARGET_ZKNH && !TARGET_64BIT"
   "sha512sig0h\t%0,%1,%2")
 
 (define_insn "riscv_sha512sig0l"
   [(set (match_operand:SI 0 "register_operand" "=r")
-    (unspec:SI
-      [(match_operand:SI 1 "register_operand" "r")
-        (match_operand:SI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:SI [(match_operand:SI 1 "register_operand" "r")
+                   (match_operand:SI 2 "register_operand" "r")]
+                   UNSPEC_SHA_512_SIG0))]
   "TARGET_ZKNH && !TARGET_64BIT"
   "sha512sig0l\t%0,%1,%2")
 
 (define_insn "riscv_sha512sig1h"
   [(set (match_operand:SI 0 "register_operand" "=r")
-    (unspec:SI
-      [(match_operand:SI 1 "register_operand" "r")
-        (match_operand:SI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:SI [(match_operand:SI 1 "register_operand" "r")
+                   (match_operand:SI 2 "register_operand" "r")]
+                   UNSPEC_SHA_512_SIG1))]
   "TARGET_ZKNH && !TARGET_64BIT"
   "sha512sig1h\t%0,%1,%2")
 
 (define_insn "riscv_sha512sig1l"
   [(set (match_operand:SI 0 "register_operand" "=r")
-    (unspec:SI
-      [(match_operand:SI 1 "register_operand" "r")
-        (match_operand:SI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:SI [(match_operand:SI 1 "register_operand" "r")
+                   (match_operand:SI 2 "register_operand" "r")]
+                   UNSPEC_SHA_512_SIG1))]
   "TARGET_ZKNH && !TARGET_64BIT"
   "sha512sig1l\t%0,%1,%2")
 
 (define_insn "riscv_sha512sum0r"
   [(set (match_operand:SI 0 "register_operand" "=r")
-    (unspec:SI
-      [(match_operand:SI 1 "register_operand" "r")
-        (match_operand:SI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:SI [(match_operand:SI 1 "register_operand" "r")
+                   (match_operand:SI 2 "register_operand" "r")]
+                   UNSPEC_SHA_512_SUM0))]
   "TARGET_ZKNH && !TARGET_64BIT"
   "sha512sum0r\t%0,%1,%2")
 
 (define_insn "riscv_sha512sum1r"
   [(set (match_operand:SI 0 "register_operand" "=r")
-    (unspec:SI
-      [(match_operand:SI 1 "register_operand" "r")
-        (match_operand:SI 2 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:SI [(match_operand:SI 1 "register_operand" "r")
+                   (match_operand:SI 2 "register_operand" "r")]
+                   UNSPEC_SHA_512_SUM0))]
   "TARGET_ZKNH && !TARGET_64BIT"
   "sha512sum1r\t%0,%1,%2")
 
@@ -218,33 +221,29 @@
 
 (define_insn "riscv_sha512sig0"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")]
+                   UNSPEC_SHA_512_SIG0))]
   "TARGET_ZKNH && TARGET_64BIT"
   "sha512sig0\t%0,%1")
 
 (define_insn "riscv_sha512sig1"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")]
+                   UNSPEC_SHA_512_SIG1))]
   "TARGET_ZKNH && TARGET_64BIT"
   "sha512sig1\t%0,%1")
 
 (define_insn "riscv_sha512sum0"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")]
+                   UNSPEC_SHA_512_SUM0))]
   "TARGET_ZKNH && TARGET_64BIT"
   "sha512sum0\t%0,%1")
 
 (define_insn "riscv_sha512sum1"
   [(set (match_operand:DI 0 "register_operand" "=r")
-    (unspec:DI
-      [(match_operand:DI 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:DI [(match_operand:DI 1 "register_operand" "r")]
+                   UNSPEC_SHA_512_SUM1))]
   "TARGET_ZKNH && TARGET_64BIT"
   "sha512sum1\t%0,%1")
 
@@ -253,17 +252,15 @@
 
 (define_insn "riscv_sm3p0_<mode>"
   [(set (match_operand:X 0 "register_operand" "=r")
-    (unspec:X
-      [(match_operand:X 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:X [(match_operand:X 1 "register_operand" "r")]
+                  UNSPEC_SM3_P0))]
   "TARGET_ZKSH"
   "sm3p0\t%0,%1")
 
 (define_insn "riscv_sm3p1_<mode>"
   [(set (match_operand:X 0 "register_operand" "=r")
-    (unspec:X
-      [(match_operand:X 1 "register_operand" "r")]
-        UNSPEC_CRYPTO))]
+        (unspec:X [(match_operand:X 1 "register_operand" "r")]
+                  UNSPEC_SM3_P1))]
   "TARGET_ZKSH"
   "sm3p1\t%0,%1")
 
@@ -272,19 +269,17 @@
 
 (define_insn "riscv_sm4ed_<mode>"
   [(set (match_operand:X 0 "register_operand" "=r")
-    (unspec:X
-      [(match_operand:X 1 "register_operand" "r")
-        (match_operand:SI 2 "immediate_operand" "")]
-        UNSPEC_CRYPTO))]
+        (unspec:X [(match_operand:X 1 "register_operand" "r")
+                  (match_operand:SI 2 "immediate_operand" "")]
+                  UNSPEC_SM4_ED))]
   "TARGET_ZKSED"
   "sm4ed\t%0,%1,%2")
 
 (define_insn "riscv_sm4ks_<mode>"
   [(set (match_operand:X 0 "register_operand" "=r")
-    (unspec:X
-      [(match_operand:X 1 "register_operand" "r")
-        (match_operand:SI 2 "immediate_operand" "")]
-        UNSPEC_CRYPTO))]
+        (unspec:X [(match_operand:X 1 "register_operand" "r")
+                  (match_operand:SI 2 "immediate_operand" "")]
+                  UNSPEC_SM4_KS))]
   "TARGET_ZKSED"
   "sm4ks\t%0,%1,%2")
 
@@ -292,11 +287,13 @@
 ;; Zkr - Entropy Source
 
 (define_insn "riscv_pollentropy_<mode>"
-  [(unspec_volatile [(match_operand:X 0 "register_operand" "=r")] UNSPEC_CRYPTO)]
+  [(set (match_operand:X 0 "register_operand" "=r")
+        (unspec:X [(const_int 0)] UNSPEC_POLLENTROPY))]
   "TARGET_ZKR"
   "pollentropy\t%0")
 
 (define_insn "riscv_getnoise_<mode>"
-  [(unspec_volatile [(match_operand:X 0 "register_operand" "=r")] UNSPEC_CRYPTO)]
+  [(set (match_operand:X 0 "register_operand" "=r")
+        (unspec:X [(const_int 0)] UNSPEC_GETNOISE))]
   "TARGET_ZKR"
   "getnoise\t%0")

--- a/gcc/config/riscv/crypto.md
+++ b/gcc/config/riscv/crypto.md
@@ -1,0 +1,302 @@
+;; Machine description for K extension.
+;; Copyright (C) 2011-2021 Free Software Foundation, Inc.
+
+;; This file is part of GCC.
+
+;; GCC is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; GCC is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GCC; see the file COPYING3.  If not see
+;; <http://www.gnu.org/licenses/>.
+
+
+;; Zkne&Zknd - AES (RV32)
+
+(define_insn "riscv_aes32dsi"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+    (unspec:SI
+      [(match_operand:SI 1 "register_operand" "r")
+        (match_operand:SI 2 "immediate_operand" "")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKND && !TARGET_64BIT"
+  "aes32dsi\t%0,%1,%2")
+
+(define_insn "riscv_aes32dsmi"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+    (unspec:SI
+      [(match_operand:SI 1 "register_operand" "r")
+        (match_operand:SI 2 "immediate_operand" "")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKND && !TARGET_64BIT"
+  "aes32dsmi\t%0,%1,%2")
+
+(define_insn "riscv_aes32esi"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+    (unspec:SI
+      [(match_operand:SI 1 "register_operand" "r")
+        (match_operand:SI 2 "immediate_operand" "")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNE && !TARGET_64BIT"
+  "aes32esi\t%0,%1,%2")
+
+(define_insn "riscv_aes32esmi"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+    (unspec:SI
+      [(match_operand:SI 1 "register_operand" "r")
+        (match_operand:SI 2 "immediate_operand" "")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNE && !TARGET_64BIT"
+  "aes32esmi\t%0,%1,%2")
+
+
+;; Zkne&Zknd - AES(RV64)
+
+(define_insn "riscv_aes64ds"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")
+        (match_operand:DI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKND && TARGET_64BIT"
+  "aes64ds\t%0,%1,%2")
+
+(define_insn "riscv_aes64dsm"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")
+        (match_operand:DI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKND && TARGET_64BIT"
+  "aes64dsm\t%0,%1,%2")
+
+(define_insn "riscv_aes64es"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")
+        (match_operand:DI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNE && TARGET_64BIT"
+  "aes64es\t%0,%1,%2")
+
+(define_insn "riscv_aes64esm"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")
+        (match_operand:DI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNE && TARGET_64BIT"
+  "aes64esm\t%0,%1,%2")
+
+(define_insn "riscv_aes64im"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKND && TARGET_64BIT"
+  "aes64im\t%0,%1")
+
+(define_insn "riscv_aes64ks1i"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")
+        (match_operand:DI 2 "immediate_operand" "")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNE && TARGET_64BIT"
+  "aes64ks1i\t%0,%1,%2")
+
+(define_insn "riscv_aes64ks2"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")
+        (match_operand:DI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNE && TARGET_64BIT"
+  "aes64ks2\t%0,%1,%2")
+
+
+;; Zknh - SHA256
+
+(define_insn "riscv_sha256sig0_<mode>"
+  [(set (match_operand:X 0 "register_operand" "=r")
+    (unspec:X
+      [(match_operand:X 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH"
+  "sha256sig0\t%0,%1")
+
+(define_insn "riscv_sha256sig1_<mode>"
+  [(set (match_operand:X 0 "register_operand" "=r")
+    (unspec:X
+      [(match_operand:X 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH"
+  "sha256sig1\t%0,%1")
+
+(define_insn "riscv_sha256sum0_<mode>"
+  [(set (match_operand:X 0 "register_operand" "=r")
+    (unspec:X
+      [(match_operand:X 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH"
+  "sha256sum0\t%0,%1")
+
+(define_insn "riscv_sha256sum1_<mode>"
+  [(set (match_operand:X 0 "register_operand" "=r")
+    (unspec:X
+      [(match_operand:X 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH"
+  "sha256sum1\t%0,%1")
+
+
+;; Zknh - SHA512 (RV32)
+
+(define_insn "riscv_sha512sig0h"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+    (unspec:SI
+      [(match_operand:SI 1 "register_operand" "r")
+        (match_operand:SI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH && !TARGET_64BIT"
+  "sha512sig0h\t%0,%1,%2")
+
+(define_insn "riscv_sha512sig0l"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+    (unspec:SI
+      [(match_operand:SI 1 "register_operand" "r")
+        (match_operand:SI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH && !TARGET_64BIT"
+  "sha512sig0l\t%0,%1,%2")
+
+(define_insn "riscv_sha512sig1h"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+    (unspec:SI
+      [(match_operand:SI 1 "register_operand" "r")
+        (match_operand:SI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH && !TARGET_64BIT"
+  "sha512sig1h\t%0,%1,%2")
+
+(define_insn "riscv_sha512sig1l"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+    (unspec:SI
+      [(match_operand:SI 1 "register_operand" "r")
+        (match_operand:SI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH && !TARGET_64BIT"
+  "sha512sig1l\t%0,%1,%2")
+
+(define_insn "riscv_sha512sum0r"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+    (unspec:SI
+      [(match_operand:SI 1 "register_operand" "r")
+        (match_operand:SI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH && !TARGET_64BIT"
+  "sha512sum0r\t%0,%1,%2")
+
+(define_insn "riscv_sha512sum1r"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+    (unspec:SI
+      [(match_operand:SI 1 "register_operand" "r")
+        (match_operand:SI 2 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH && !TARGET_64BIT"
+  "sha512sum1r\t%0,%1,%2")
+
+
+;; Zknh - SHA512 (RV64)
+
+(define_insn "riscv_sha512sig0"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH && TARGET_64BIT"
+  "sha512sig0\t%0,%1")
+
+(define_insn "riscv_sha512sig1"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH && TARGET_64BIT"
+  "sha512sig1\t%0,%1")
+
+(define_insn "riscv_sha512sum0"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH && TARGET_64BIT"
+  "sha512sum0\t%0,%1")
+
+(define_insn "riscv_sha512sum1"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+    (unspec:DI
+      [(match_operand:DI 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKNH && TARGET_64BIT"
+  "sha512sum1\t%0,%1")
+
+
+;; Zksh - SM3
+
+(define_insn "riscv_sm3p0_<mode>"
+  [(set (match_operand:X 0 "register_operand" "=r")
+    (unspec:X
+      [(match_operand:X 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKSH"
+  "sm3p0\t%0,%1")
+
+(define_insn "riscv_sm3p1_<mode>"
+  [(set (match_operand:X 0 "register_operand" "=r")
+    (unspec:X
+      [(match_operand:X 1 "register_operand" "r")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKSH"
+  "sm3p1\t%0,%1")
+
+
+;; Zksed - SM4
+
+(define_insn "riscv_sm4ed_<mode>"
+  [(set (match_operand:X 0 "register_operand" "=r")
+    (unspec:X
+      [(match_operand:X 1 "register_operand" "r")
+        (match_operand:SI 2 "immediate_operand" "")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKSED"
+  "sm4ed\t%0,%1,%2")
+
+(define_insn "riscv_sm4ks_<mode>"
+  [(set (match_operand:X 0 "register_operand" "=r")
+    (unspec:X
+      [(match_operand:X 1 "register_operand" "r")
+        (match_operand:SI 2 "immediate_operand" "")]
+        UNSPEC_CRYPTO))]
+  "TARGET_ZKSED"
+  "sm4ks\t%0,%1,%2")
+
+
+;; Zkr - Entropy Source
+
+(define_insn "riscv_pollentropy_<mode>"
+  [(unspec_volatile [(match_operand:X 0 "register_operand" "=r")] UNSPEC_CRYPTO)]
+  "TARGET_ZKR"
+  "pollentropy\t%0")
+
+(define_insn "riscv_getnoise_<mode>"
+  [(unspec_volatile [(match_operand:X 0 "register_operand" "=r")] UNSPEC_CRYPTO)]
+  "TARGET_ZKR"
+  "getnoise\t%0")

--- a/gcc/config/riscv/multilib-generator
+++ b/gcc/config/riscv/multilib-generator
@@ -48,7 +48,7 @@ abis = collections.OrderedDict()
 required = []
 reuse = []
 
-canonical_order = "mafdgqlcbjtpvn"
+canonical_order = "mafdgqlcbjktpvn"
 LONG_EXT_PREFIXES = ['z', 's', 'h', 'x']
 
 #

--- a/gcc/config/riscv/riscv-builtins-crypto.def
+++ b/gcc/config/riscv/riscv-builtins-crypto.def
@@ -1,0 +1,73 @@
+/* Builtin definitions for K extension
+   Copyright (C) 2021 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3, or (at your option)
+any later version.
+
+GCC is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+// AES32
+DIRECT_BUILTIN (aes32dsi, RISCV_SI_FTYPE_SI_SI, crypto_zknd32),
+DIRECT_BUILTIN (aes32dsmi, RISCV_SI_FTYPE_SI_SI, crypto_zknd32),
+DIRECT_BUILTIN (aes32esi, RISCV_SI_FTYPE_SI_SI, crypto_zkne32),
+DIRECT_BUILTIN (aes32esmi, RISCV_SI_FTYPE_SI_SI, crypto_zkne32),
+
+// AES64
+DIRECT_BUILTIN (aes64ds, RISCV_DI_FTYPE_DI_DI, crypto_zknd64),
+DIRECT_BUILTIN (aes64dsm, RISCV_DI_FTYPE_DI_DI, crypto_zknd64),
+DIRECT_BUILTIN (aes64es, RISCV_DI_FTYPE_DI_DI, crypto_zkne64),
+DIRECT_BUILTIN (aes64esm, RISCV_DI_FTYPE_DI_DI, crypto_zkne64),
+DIRECT_BUILTIN (aes64im, RISCV_DI_FTYPE_DI, crypto_zknd64),
+DIRECT_BUILTIN (aes64ks1i, RISCV_DI_FTYPE_DI_SI, crypto_zkne64),
+DIRECT_BUILTIN (aes64ks2, RISCV_DI_FTYPE_DI_DI, crypto_zkne64),
+
+// SHA256
+RISCV_BUILTIN (sha256sig0_si, "sha256sig0", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zknh32),
+RISCV_BUILTIN (sha256sig0_di, "sha256sig0", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, crypto_zknh64),
+RISCV_BUILTIN (sha256sig1_si, "sha256sig1", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zknh32),
+RISCV_BUILTIN (sha256sig1_di, "sha256sig1", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, crypto_zknh64),
+RISCV_BUILTIN (sha256sum0_si, "sha256sum0", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zknh32),
+RISCV_BUILTIN (sha256sum0_di, "sha256sum0", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, crypto_zknh64),
+RISCV_BUILTIN (sha256sum1_si, "sha256sum1", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zknh32),
+RISCV_BUILTIN (sha256sum1_di, "sha256sum1", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, crypto_zknh64),
+
+// SHA512 (32)
+DIRECT_BUILTIN (sha512sig0h, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
+DIRECT_BUILTIN (sha512sig0l, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
+DIRECT_BUILTIN (sha512sig1h, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
+DIRECT_BUILTIN (sha512sig1l, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
+DIRECT_BUILTIN (sha512sum0r, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
+DIRECT_BUILTIN (sha512sum1r, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
+
+// SHA512 (64)
+DIRECT_BUILTIN (sha512sig0, RISCV_DI_FTYPE_DI_DI, crypto_zknh64),
+DIRECT_BUILTIN (sha512sig1, RISCV_DI_FTYPE_DI_DI, crypto_zknh64),
+DIRECT_BUILTIN (sha512sum0, RISCV_DI_FTYPE_DI_DI, crypto_zknh64),
+DIRECT_BUILTIN (sha512sum1, RISCV_DI_FTYPE_DI_DI, crypto_zknh64),
+
+// SM3/4
+RISCV_BUILTIN (sm3p0_si, "sm3p0", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zksh32),
+RISCV_BUILTIN (sm3p0_di, "sm3p0", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, crypto_zksh64),
+RISCV_BUILTIN (sm3p1_si, "sm3p1", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zksh32),
+RISCV_BUILTIN (sm3p1_di, "sm3p1", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, crypto_zksh64),
+RISCV_BUILTIN (sm4ed_si, "sm4ed", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI, crypto_zksed32),
+RISCV_BUILTIN (sm4ed_di, "sm4ed", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI_SI, crypto_zksed64),
+RISCV_BUILTIN (sm4ks_si, "sm4ks", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI, crypto_zksed32),
+RISCV_BUILTIN (sm4ks_di, "sm4ks", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI_SI, crypto_zksed64),
+
+// ZKR
+RISCV_BUILTIN (pollentropy_si, "pollentropy", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, crypto_zkr32),
+RISCV_BUILTIN (pollentropy_di, "pollentropy", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, crypto_zkr64),
+RISCV_BUILTIN (getnoise_si, "getnoise", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, crypto_zkr32),
+RISCV_BUILTIN (getnoise_di, "getnoise", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, crypto_zkr64),

--- a/gcc/config/riscv/riscv-builtins-crypto.def
+++ b/gcc/config/riscv/riscv-builtins-crypto.def
@@ -17,13 +17,13 @@ You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
 
-// AES32
+// Zkne&Zknd - AES (RV32)
 DIRECT_BUILTIN (aes32dsi, RISCV_SI_FTYPE_SI_SI, crypto_zknd32),
 DIRECT_BUILTIN (aes32dsmi, RISCV_SI_FTYPE_SI_SI, crypto_zknd32),
 DIRECT_BUILTIN (aes32esi, RISCV_SI_FTYPE_SI_SI, crypto_zkne32),
 DIRECT_BUILTIN (aes32esmi, RISCV_SI_FTYPE_SI_SI, crypto_zkne32),
 
-// AES64
+// Zkne&Zknd - AES(RV64)
 DIRECT_BUILTIN (aes64ds, RISCV_DI_FTYPE_DI_DI, crypto_zknd64),
 DIRECT_BUILTIN (aes64dsm, RISCV_DI_FTYPE_DI_DI, crypto_zknd64),
 DIRECT_BUILTIN (aes64es, RISCV_DI_FTYPE_DI_DI, crypto_zkne64),
@@ -32,7 +32,7 @@ DIRECT_BUILTIN (aes64im, RISCV_DI_FTYPE_DI, crypto_zknd64),
 DIRECT_BUILTIN (aes64ks1i, RISCV_DI_FTYPE_DI_SI, crypto_zkne64),
 DIRECT_BUILTIN (aes64ks2, RISCV_DI_FTYPE_DI_DI, crypto_zkne64),
 
-// SHA256
+// Zknh - SHA256
 RISCV_BUILTIN (sha256sig0_si, "sha256sig0", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zknh32),
 RISCV_BUILTIN (sha256sig0_di, "sha256sig0", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, crypto_zknh64),
 RISCV_BUILTIN (sha256sig1_si, "sha256sig1", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zknh32),
@@ -42,7 +42,7 @@ RISCV_BUILTIN (sha256sum0_di, "sha256sum0", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE
 RISCV_BUILTIN (sha256sum1_si, "sha256sum1", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zknh32),
 RISCV_BUILTIN (sha256sum1_di, "sha256sum1", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, crypto_zknh64),
 
-// SHA512 (32)
+// Zknh - SHA512 (RV32)
 DIRECT_BUILTIN (sha512sig0h, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
 DIRECT_BUILTIN (sha512sig0l, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
 DIRECT_BUILTIN (sha512sig1h, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
@@ -50,23 +50,25 @@ DIRECT_BUILTIN (sha512sig1l, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
 DIRECT_BUILTIN (sha512sum0r, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
 DIRECT_BUILTIN (sha512sum1r, RISCV_SI_FTYPE_SI_SI, crypto_zknh32),
 
-// SHA512 (64)
+// Zknh - SHA512 (RV64)
 DIRECT_BUILTIN (sha512sig0, RISCV_DI_FTYPE_DI_DI, crypto_zknh64),
 DIRECT_BUILTIN (sha512sig1, RISCV_DI_FTYPE_DI_DI, crypto_zknh64),
 DIRECT_BUILTIN (sha512sum0, RISCV_DI_FTYPE_DI_DI, crypto_zknh64),
 DIRECT_BUILTIN (sha512sum1, RISCV_DI_FTYPE_DI_DI, crypto_zknh64),
 
-// SM3/4
+// Zksh - SM3
 RISCV_BUILTIN (sm3p0_si, "sm3p0", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zksh32),
 RISCV_BUILTIN (sm3p0_di, "sm3p0", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, crypto_zksh64),
 RISCV_BUILTIN (sm3p1_si, "sm3p1", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, crypto_zksh32),
 RISCV_BUILTIN (sm3p1_di, "sm3p1", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, crypto_zksh64),
+
+// Zksed - SM4
 RISCV_BUILTIN (sm4ed_si, "sm4ed", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI, crypto_zksed32),
 RISCV_BUILTIN (sm4ed_di, "sm4ed", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI_SI, crypto_zksed64),
 RISCV_BUILTIN (sm4ks_si, "sm4ks", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI, crypto_zksed32),
 RISCV_BUILTIN (sm4ks_di, "sm4ks", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI_SI, crypto_zksed64),
 
-// ZKR
+// Zkr - Entropy Source
 RISCV_BUILTIN (pollentropy_si, "pollentropy", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, crypto_zkr32),
 RISCV_BUILTIN (pollentropy_di, "pollentropy", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, crypto_zkr64),
 RISCV_BUILTIN (getnoise_si, "getnoise", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, crypto_zkr32),

--- a/gcc/config/riscv/riscv-builtins.c
+++ b/gcc/config/riscv/riscv-builtins.c
@@ -40,6 +40,7 @@ along with GCC; see the file COPYING3.  If not see
 /* Macros to create an enumeration identifier for a function prototype.  */
 #define RISCV_FTYPE_NAME0(A) RISCV_##A##_FTYPE
 #define RISCV_FTYPE_NAME1(A, B) RISCV_##A##_FTYPE_##B
+#define RISCV_FTYPE_NAME2(A, B, C) RISCV_##A##_FTYPE_##B##_##C
 
 /* Classifies the prototype of a built-in function.  */
 enum riscv_function_type {
@@ -87,6 +88,21 @@ struct riscv_builtin_description {
 
 AVAIL (hard_float, TARGET_HARD_FLOAT)
 
+AVAIL (crypto_zknd32, TARGET_ZKND && !TARGET_64BIT)
+AVAIL (crypto_zknd64, TARGET_ZKND && TARGET_64BIT)
+AVAIL (crypto_zkne32, TARGET_ZKNE && !TARGET_64BIT)
+AVAIL (crypto_zkne64, TARGET_ZKNE && TARGET_64BIT)
+AVAIL (crypto_zknh32, TARGET_ZKNH && !TARGET_64BIT)
+AVAIL (crypto_zknh64, TARGET_ZKNH && TARGET_64BIT)
+
+AVAIL (crypto_zksh32, TARGET_ZKSH && !TARGET_64BIT)
+AVAIL (crypto_zksh64, TARGET_ZKSH && TARGET_64BIT)
+AVAIL (crypto_zksed32, TARGET_ZKSED && !TARGET_64BIT)
+AVAIL (crypto_zksed64, TARGET_ZKSED && TARGET_64BIT)
+
+AVAIL (crypto_zkr32, TARGET_ZKR && !TARGET_64BIT)
+AVAIL (crypto_zkr64, TARGET_ZKR && TARGET_64BIT)
+
 /* Construct a riscv_builtin_description from the given arguments.
 
    INSN is the name of the associated instruction pattern, without the
@@ -119,6 +135,8 @@ AVAIL (hard_float, TARGET_HARD_FLOAT)
 /* Argument types.  */
 #define RISCV_ATYPE_VOID void_type_node
 #define RISCV_ATYPE_USI unsigned_intSI_type_node
+#define RISCV_ATYPE_SI intSI_type_node
+#define RISCV_ATYPE_DI intDI_type_node
 
 /* RISCV_FTYPE_ATYPESN takes N RISCV_FTYPES-like type codes and lists
    their associated RISCV_ATYPEs.  */
@@ -126,8 +144,12 @@ AVAIL (hard_float, TARGET_HARD_FLOAT)
   RISCV_ATYPE_##A
 #define RISCV_FTYPE_ATYPES1(A, B) \
   RISCV_ATYPE_##A, RISCV_ATYPE_##B
+#define RISCV_FTYPE_ATYPES2(A, B, C) \
+  RISCV_ATYPE_##A, RISCV_ATYPE_##B, RISCV_ATYPE_##C
 
 static const struct riscv_builtin_description riscv_builtins[] = {
+  #include "riscv-builtins-crypto.def"
+
   DIRECT_BUILTIN (frflags, RISCV_USI_FTYPE, hard_float),
   DIRECT_NO_TARGET_BUILTIN (fsflags, RISCV_VOID_FTYPE_USI, hard_float)
 };

--- a/gcc/config/riscv/riscv-ftypes.def
+++ b/gcc/config/riscv/riscv-ftypes.def
@@ -27,4 +27,11 @@ along with GCC; see the file COPYING3.  If not see
         argument type.  */
 
 DEF_RISCV_FTYPE (0, (USI))
+DEF_RISCV_FTYPE (0, (SI))
+DEF_RISCV_FTYPE (0, (DI))
 DEF_RISCV_FTYPE (1, (VOID, USI))
+DEF_RISCV_FTYPE (1, (SI, SI))
+DEF_RISCV_FTYPE (1, (DI, DI))
+DEF_RISCV_FTYPE (2, (SI, SI, SI))
+DEF_RISCV_FTYPE (2, (DI, DI, DI))
+DEF_RISCV_FTYPE (2, (DI, DI, SI))

--- a/gcc/config/riscv/riscv-opts.h
+++ b/gcc/config/riscv/riscv-opts.h
@@ -51,4 +51,22 @@ enum riscv_align_data {
   riscv_align_data_type_natural
 };
 
+#define MASK_ZKG (1 << 0)
+#define MASK_ZKB (1 << 1)
+#define MASK_ZKR (1 << 2)
+#define MASK_ZKNE (1 << 3)
+#define MASK_ZKND (1 << 4)
+#define MASK_ZKNH (1 << 5)
+#define MASK_ZKSED (1 << 6)
+#define MASK_ZKSH (1 << 7)
+
+#define TARGET_ZKG ((riscv_crypto_subext & MASK_ZKG) != 0)
+#define TARGET_ZKB ((riscv_crypto_subext & MASK_ZKB) != 0)
+#define TARGET_ZKR ((riscv_crypto_subext & MASK_ZKR) != 0)
+#define TARGET_ZKNE ((riscv_crypto_subext & MASK_ZKNE) != 0)
+#define TARGET_ZKND ((riscv_crypto_subext & MASK_ZKND) != 0)
+#define TARGET_ZKNH ((riscv_crypto_subext & MASK_ZKNH) != 0)
+#define TARGET_ZKSED ((riscv_crypto_subext & MASK_ZKSED) != 0)
+#define TARGET_ZKSH ((riscv_crypto_subext & MASK_ZKSH) != 0)
+
 #endif /* ! GCC_RISCV_OPTS_H */

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -43,9 +43,6 @@
   UNSPEC_LRINT
   UNSPEC_LROUND
 
-  ;; Crypto extension unspecs.
-  UNSPEC_CRYPTO
-
   ;; Stack tie
   UNSPEC_TIE
 ])

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -43,6 +43,9 @@
   UNSPEC_LRINT
   UNSPEC_LROUND
 
+  ;; Crypto extension unspecs.
+  UNSPEC_CRYPTO
+
   ;; Stack tie
   UNSPEC_TIE
 ])
@@ -2497,6 +2500,8 @@
   ""
   [(set_attr "length" "0")]
 )
+
+(include "crypto.md")
 
 ;; This fixes a failure with gcc.c-torture/execute/pr64242.c at -O2 for a
 ;; 32-bit target when using -mtune=sifive-7-series.  The first sched pass

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -155,3 +155,6 @@ Enum(riscv_align_data) String(xlen) Value(riscv_align_data_type_xlen)
 
 EnumValue
 Enum(riscv_align_data) String(natural) Value(riscv_align_data_type_natural)
+
+TargetVariable
+int riscv_crypto_subext


### PR DESCRIPTION
add instructions (and their builtins) in K-ext spec v0.9.0, except those in Zkb and Zkg which is waiting for ext-b's work to prevent conflict.