### PR TITLE
Update 2 C++ coroutine testcases from upstream.

### DIFF
--- a/gcc/testsuite/g++.dg/coroutines/torture/co-ret-17-void-ret-coro.C
+++ b/gcc/testsuite/g++.dg/coroutines/torture/co-ret-17-void-ret-coro.C
@@ -5,20 +5,23 @@
 
 #include "../coro.h"
 
+int g_promise = -1;
+
 template<typename R, typename HandleRef, typename ...T>
 struct std::coroutine_traits<R, HandleRef, T...> {
     struct promise_type {
         promise_type (HandleRef h, T ...args)
         { h = std::coroutine_handle<promise_type>::from_promise (*this);
           PRINT ("Created Promise");
+          g_promise = 1;
         }
-
+	~promise_type () { PRINT ("Destroyed Promise"); g_promise = 0;}
         void get_return_object() {}
 
         auto initial_suspend() {
           return std::suspend_always{};
          }
-        auto final_suspend() { return std::suspend_never{}; }
+        auto final_suspend() noexcept { return std::suspend_never{}; }
 
         void return_void() {}
         void unhandled_exception() {}
@@ -45,10 +48,11 @@ int main ()
 
   // initial suspend.
   h.resume ();
-  
-  if (!h.done())
+
+  // The coro should have self-destructed.
+  if (g_promise)
     {
-      PRINT ("main: apparently wasn't done...");
+      PRINT ("main: apparently we did not complete...");
       abort ();
     }
 

--- a/gcc/testsuite/g++.dg/coroutines/torture/pr95519-05-gro.C
+++ b/gcc/testsuite/g++.dg/coroutines/torture/pr95519-05-gro.C
@@ -5,7 +5,7 @@
 struct pt_b
 {
   std::suspend_always initial_suspend() const noexcept { return {}; }
-  std::suspend_never final_suspend() const noexcept { return {}; }
+  std::suspend_always final_suspend() const noexcept { return {}; }
   constexpr void return_void () noexcept {};
   constexpr void unhandled_exception() const noexcept {}
 };


### PR DESCRIPTION
Fixes use-after-free bugs exposed by new glibc version.