### PR TITLE
[bitmanip] Generate sext.[bh] for sign-extension under ZBB

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -444,3 +444,16 @@
   [(set_attr "type" "bitmanip")])
 
 ;; ??? bfxp
+
+;; sext
+
+(define_insn "*extend<SHORT:mode><SUPERQI:mode>2_bitmanip"
+  [(set (match_operand:SUPERQI 0 "register_operand" "=r,r")
+	(sign_extend:SUPERQI
+	    (match_operand:SHORT 1 "nonimmediate_operand" " r,m")))]
+  "TARGET_ZBB"
+  "@
+   sext.<SHORT:size>\t%0,%1
+   l<SHORT:size>\t%0,%1"
+  [(set_attr "type" "bitmanip")
+   (set_attr "length" "4")])

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1134,11 +1134,16 @@
   [(set_attr "move_type" "move,load")
    (set_attr "mode" "DI")])
 
-(define_insn_and_split "extend<SHORT:mode><SUPERQI:mode>2"
+(define_expand "extend<SHORT:mode><SUPERQI:mode>2"
+  [(set (match_operand:SUPERQI 0 "register_operand" "")
+    (sign_extend:SUPERQI
+	    (match_operand:SHORT 1 "nonimmediate_operand" "")))])
+
+(define_insn_and_split "*extend<SHORT:mode><SUPERQI:mode>2"
   [(set (match_operand:SUPERQI   0 "register_operand"     "=r,r")
 	(sign_extend:SUPERQI
 	    (match_operand:SHORT 1 "nonimmediate_operand" " r,m")))]
-  ""
+  "!TARGET_ZBB"
   "@
    #
    l<SHORT:size>\t%0,%1"

--- a/gcc/testsuite/gcc.target/riscv/rvb-zbb-sext_b.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-zbb-sext_b.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32gc_zbb -O2" { target { riscv32*-*-* } } } */
+/* { dg-options "-march=rv64gc_zbb -O2" { target { riscv64*-*-* } } } */
+
+long sext_h(long a) {
+	return (signed char)a;
+}
+
+/* { dg-final { scan-assembler-times "sext.b\t" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/rvb-zbb-sext_h.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-zbb-sext_h.c
@@ -1,0 +1,9 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32gc_zbb -O2" { target { riscv32*-*-* } } } */
+/* { dg-options "-march=rv64gc_zbb -O2" { target { riscv64*-*-* } } } */
+
+long sext_h(long a) {
+	return (short)a;
+}
+
+/* { dg-final { scan-assembler-times "sext.h\t" 1 } } */


### PR DESCRIPTION
This simply adds a new define_insn for sext.[bh] when ZBB is available (and deactivate the existing define_insn_and_split for sign_extend).