### PR TITLE
Merge bswapsi2_32 and bswapsi2_64

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -349,27 +349,16 @@
 
 ;;; ??? grev
 
-(define_expand "bswapsi2"
-  [(set (match_operand:SI 0 "register_operand")
-	(bswap:SI (match_operand:SI 1 "register_operand")))]
-  ""
+(define_insn "bswapsi2"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+        (bswap:SI (match_operand:SI 1 "register_operand" "r")))]
+  "TARGET_ZBB || TARGET_ZBP"
 {
-  if (!(TARGET_ZBP || (TARGET_ZBB && !TARGET_64BIT)))
-    FAIL;
-})
-
-(define_insn "bswapsi2_32"
-  [(set (match_operand:SI 0 "register_operand" "=r")
-	(bswap:SI (match_operand:SI 1 "register_operand" "r")))]
-  "!TARGET_64BIT && (TARGET_ZBB || TARGET_ZBP)"
-  { return "rev8\t%0,%1"; }
-  [(set_attr "type" "bitmanip")])
-
-(define_insn "bswapsi2_64"
-  [(set (match_operand:SI 0 "register_operand" "=r")
-	(bswap:SI (match_operand:SI 1 "register_operand" "r")))]
-  "TARGET_64BIT && TARGET_ZBP"
-  { return "rev8.w\t%0,%1"; }
+  if (TARGET_64BIT)
+    return TARGET_ZBB ? "rev8\t%0,%1\n\tsrai\t%0,%0,32" : "rev8.w\t%0,%1";
+  else
+    return "rev8\t%0,%1";
+}
   [(set_attr "type" "bitmanip")])
 
 (define_insn "bswapdi2"


### PR DESCRIPTION
#271 surprisingly break the non-B target, because using define_expand will cause bswap optimizaion always enabled even
 no bswap on target, that will made __bswapsi2 optimize to an infinite  recursion call.

Testcase:
```c
typedef unsigned SItype;
    SItype
__bswapsi2 (SItype u)
{
  return ((((u) & 0xff000000) >> 24)
          | (((u) & 0x00ff0000) >>  8)
          | (((u) & 0x0000ff00) <<  8)
          | (((u) & 0x000000ff) << 24));
}
```