### PR TITLE
[bitmanip] Generate cmov under ZBT

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -399,6 +399,26 @@
 
 ;;; ??? cmov
 
+(define_insn "*mov<X:mode>cc_ne_bitmanip"
+  [(set (match_operand:X 0 "register_operand" "=r")
+	(if_then_else:X
+	 (ne (match_operand:X 1 "register_operand" "r") (const_int 0))
+	 (match_operand:X 2 "register_operand" "r")
+	 (match_operand:X 3 "register_operand" "r")))]
+  "TARGET_ZBT"
+  "cmov\t%0,%1,%2,%3"
+  [(set_attr "type" "bitmanip")])
+
+(define_insn "*mov<X:mode>cc_eq_bitmanip"
+  [(set (match_operand:X 0 "register_operand" "=r")
+	(if_then_else:X
+	 (eq (match_operand:X 1 "register_operand" "r") (const_int 0))
+	 (match_operand:X 2 "register_operand" "r")
+	 (match_operand:X 3 "register_operand" "r")))]
+  "TARGET_ZBT"
+  "cmov\t%0,%1,%3,%2"
+  [(set_attr "type" "bitmanip")])
+
 ;;; ??? fs[lr]
 
 (define_insn "*shNadd"

--- a/gcc/testsuite/gcc.target/riscv/rvb-zbt-cmov.c
+++ b/gcc/testsuite/gcc.target/riscv/rvb-zbt-cmov.c
@@ -1,0 +1,12 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32gc_zbt -O2" { target { riscv32*-*-* } } } */
+/* { dg-options "-march=rv64gc_zbt -O2" { target { riscv64*-*-* } } } */
+
+long cmov(long s, long b, long c) {
+        return (s ? b : c);
+}
+long cmov2(long s, long b, long c) {
+        return (s == 0 ? b : c);
+}
+
+/* { dg-final { scan-assembler-times "cmov\t" 2 } } */


### PR DESCRIPTION

Add basic support for cmov (ZBT), for [not]equal 0.

Signed-off-by: Romain Dolbeau <romain.dolbeau@european-processor-initiative.eu>